### PR TITLE
fix(add): abort will now abort importing an item entirely

### DIFF
--- a/moe/plugins/add/add.py
+++ b/moe/plugins/add/add.py
@@ -16,6 +16,7 @@ from moe.core.library.album import Album
 from moe.core.library.extra import Extra
 from moe.core.library.lib_item import LibItem
 from moe.core.library.track import Track, TrackError
+from moe.plugins import add
 
 __all__ = ["add_item", "AddError"]
 
@@ -62,6 +63,8 @@ def _parse_args(config: Config, session: Session, args: argparse.Namespace):
             add_item(config, session, path)
         except AddError as exc:
             log.error(exc)
+            error_count += 1
+        except add.AbortImport:
             error_count += 1
 
     if error_count:

--- a/moe/plugins/add/prompt.py
+++ b/moe/plugins/add/prompt.py
@@ -19,9 +19,13 @@ from moe.core.library.lib_item import LibItem
 from moe.core.library.track import Track
 from moe.plugins import add
 
-__all__ = ["PromptChoice", "import_prompt"]
+__all__ = ["AbortImport", "import_prompt", "PromptChoice"]
 
 log = logging.getLogger("moe.add")
+
+
+class AbortImport(Exception):
+    """Used to abort the import process."""
 
 
 class PromptChoice(NamedTuple):
@@ -230,4 +234,4 @@ def _abort_changes(
     new_album: Album,
 ):
     """Aborts the album changes."""
-    pass  # noqa: WPS420
+    raise AbortImport()

--- a/tests/test_add/test_prompt.py
+++ b/tests/test_add/test_prompt.py
@@ -5,6 +5,8 @@ import datetime
 import random
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
 from moe.core.library.album import Album
 from moe.plugins import add
 
@@ -62,7 +64,8 @@ class TestImportPrompt:
         mock_q = Mock()
         mock_q.ask.return_value = add.prompt._abort_changes
         with patch("moe.plugins.add.prompt.questionary.rawselect", return_value=mock_q):
-            add.prompt.import_prompt(config, MagicMock(), mock_album, new_album)
+            with pytest.raises(add.AbortImport):
+                add.prompt.import_prompt(config, MagicMock(), mock_album, new_album)
 
         assert mock_album.is_unique(new_album)
 


### PR DESCRIPTION
Before, it was still adding the original album and just aborting the metadata changes to the album.