### PR TITLE
test(codecov): remove coverage report from the tests themselves

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,6 @@ coverage:
   status:
     project: off
     patch: off
+
+ignore:
+  "tests"


### PR DESCRIPTION
We don't care about coverage of test cases. This will vary according to platform, OS, etc.