### PR TITLE
refactor(cli): aborts now exit with code 0

### DIFF
--- a/moe/plugins/add/add_cli.py
+++ b/moe/plugins/add/add_cli.py
@@ -13,6 +13,7 @@ from moe.library.extra import Extra
 from moe.library.lib_item import LibItem
 from moe.library.track import Track
 from moe.plugins import add as moe_add
+from moe.plugins.add.add_core.add import AddAbortError
 
 log = logging.getLogger("moe.add")
 
@@ -64,7 +65,10 @@ def pre_add(config: Config, item: LibItem):
         "Duplicate item already exists in the library, how would you like to"
         " resolve it?",
     )
-    prompt_choice.func(config, album, dup_album)
+    try:
+        prompt_choice.func(config, album, dup_album)
+    except AddAbortError as err:
+        raise SystemExit(0) from err
 
 
 @moe.hookimpl

--- a/moe/plugins/add/add_core/add.py
+++ b/moe/plugins/add/add_core/add.py
@@ -101,7 +101,6 @@ def add_item(config: Config, item_path: Path):
         item_path: Filesystem path of the item.
 
     Raises:
-        AddAbortError: Add process was aborted by the user.
         AddError: Unable to add the item to the library.
         NotImplementedError: Attempting to add an Extra.
     """

--- a/moe/plugins/moe_import/import_cli.py
+++ b/moe/plugins/moe_import/import_cli.py
@@ -65,7 +65,7 @@ def process_candidates(config: Config, old_album: Album, candidates):
         try:
             import_prompt(config, old_album, candidates[0])
         except AbortImport as err:
-            raise SystemExit(1) from err
+            raise SystemExit(0) from err
 
 
 @moe.hookimpl

--- a/tests/plugins/add/test_add_cli.py
+++ b/tests/plugins/add/test_add_cli.py
@@ -150,13 +150,15 @@ class TestPreAdd:
         assert album.get_existing()
 
         mock_prompt_choice = moe.cli.PromptChoice("mock", "m", add.add_cli._abort)
-        with pytest.raises(add.AddAbortError):
+        with pytest.raises(SystemExit) as error:
             with patch.object(
                 moe.cli, "choice_prompt", return_value=mock_prompt_choice
             ):
                 tmp_add_config.plugin_manager.hook.pre_add(
                     config=tmp_add_config, item=album
                 )
+
+        assert error.value.code == 0
 
     def test_merge(self, mock_album_factory, tmp_session, tmp_add_config):
         """Test merging the two albums, without overwriting on conflict."""

--- a/tests/plugins/import/test_import_cli.py
+++ b/tests/plugins/import/test_import_cli.py
@@ -122,7 +122,7 @@ class TestProcessCandidates:
                     candidates=[Mock()],
                 )
 
-        assert error.value.code != 0
+        assert error.value.code == 0
 
     def test_process_no_candidates(self, tmp_import_config):
         """Don't display the import prompt if there are no candidates to process."""


### PR DESCRIPTION
Aborts are normal exit points for the program, and not really errors.