### PR TITLE
refactor: item.fields is now a property returning a set

### DIFF
--- a/moe/library/lib_item.py
+++ b/moe/library/lib_item.py
@@ -209,7 +209,8 @@ class LibItem:
         """A library item's filesystem path."""
         raise NotImplementedError
 
-    def fields(self) -> tuple[str, ...]:
+    @property
+    def fields(self) -> set[str]:
         """Returns the public attributes of an item."""
         raise NotImplementedError
 

--- a/moe/plugins/info.py
+++ b/moe/plugins/info.py
@@ -9,7 +9,7 @@ Note:
 import argparse
 import logging
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any
 
 import moe
 import moe.cli
@@ -124,7 +124,6 @@ def _fmt_track_info(track: Track) -> str:
     """Formats a track's information for display."""
     base_dict = OrderedDict(sorted(_get_base_dict(track).items()))
     base_dict.pop("album_obj", None)
-    base_dict.pop("genres", None)
 
     return "\n".join(
         f"{field}: {value}"
@@ -132,7 +131,7 @@ def _fmt_track_info(track: Track) -> str:
     )
 
 
-def _get_base_dict(item: LibItem) -> Dict[str, Any]:
+def _get_base_dict(item: LibItem) -> dict[str, Any]:
     """Represents an item as a dictionary.
 
     Only public attributes that are not empty will be included. Also, any attributes
@@ -146,7 +145,7 @@ def _get_base_dict(item: LibItem) -> Dict[str, Any]:
         Returns a dict representation of an Item in the form { attribute: value }.
     """
     item_dict = {}
-    for attr in item.fields():
+    for attr in sorted(item.fields):
         value = getattr(item, attr)
         if value:
             item_dict[attr] = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,8 +194,10 @@ def track_factory(
             setattr(track, field, value)
 
     if dup_track:
-        for field in dup_track.fields():
+        for field in dup_track.fields:
             value = getattr(dup_track, field)
+            if field == "genre":
+                print(value)
             try:
                 setattr(track, field, value)
             except AttributeError:
@@ -242,7 +244,7 @@ def extra_factory(
             setattr(extra, field, value)
 
     if dup_extra:
-        for field in dup_extra.fields():
+        for field in dup_extra.fields:
             value = getattr(dup_extra, field)
             try:
                 setattr(extra, field, value)
@@ -301,7 +303,7 @@ def album_factory(
             setattr(album, field, value)
 
     if dup_album:
-        for field in dup_album.fields():
+        for field in dup_album.fields:
             if field not in ["tracks", "extras"]:
                 value = getattr(dup_album, field)
                 try:

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -177,7 +177,7 @@ class TestEquality:
 
     def test_equals(self):
         """Tracks with the same metadata are equal."""
-        track1 = track_factory(custom="custom")
+        track1 = track_factory()
         track2 = track_factory(dup_track=track1)
 
         assert track1 == track2


### PR DESCRIPTION
Being a set brings it more useful options such as set intersection, union, etc. and can still be sorted if needed.

<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--153.org.readthedocs.build/en/153/

<!-- readthedocs-preview mrmoe end -->