### PR TITLE
refactor: library items now all importable under `library` package

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -19,7 +19,7 @@ from logging.config import fileConfig
 
 from alembic import context
 from moe.config import Config
-from moe.library import SABase
+from moe.library.lib_item import SABase
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/docs/developers/api/core.rst
+++ b/docs/developers/api/core.rst
@@ -24,44 +24,9 @@ Library
 
 ``library`` subpackage.
 
-General
--------
-
-``lib_item`` submodule.
-
-.. automodule:: moe.library.lib_item
+.. automodule:: moe.library
    :members:
-   :exclude-members: cache_ok
-
-
-Album
------
-
-``album`` submodule.
-
-.. automodule:: moe.library.album
-   :members:
-   :exclude-members: year, path
-   :show-inheritance:
-
-Track
------
-
-``track`` submodule.
-
-.. automodule:: moe.library.track
-   :members:
-   :exclude-members: genre, path
-   :show-inheritance:
-
-Extra
------
-
-``extra`` submodule.
-
-.. automodule:: moe.library.extra
-   :members:
-   :exclude-members: path
+   :exclude-members: cache_ok, path, year, genre
    :show-inheritance:
 
 

--- a/moe/library/__init__.py
+++ b/moe/library/__init__.py
@@ -1,5 +1,13 @@
 """Moe database/library functionality."""
 
-from sqlalchemy.orm import declarative_base
+from . import album, extra, lib_item, track
+from .album import *
+from .extra import *
+from .lib_item import *
+from .track import *
 
-SABase = declarative_base()
+__all__ = []
+__all__.extend(album.__all__)
+__all__.extend(extra.__all__)
+__all__.extend(lib_item.__all__)
+__all__.extend(track.__all__)

--- a/moe/library/album.py
+++ b/moe/library/album.py
@@ -14,14 +14,13 @@ from sqlalchemy.orm import relationship
 
 import moe
 from moe import config
-from moe.library import SABase
-from moe.library.lib_item import LibItem, LibraryError, PathType
+from moe.library.lib_item import LibItem, LibraryError, PathType, SABase
 
 if TYPE_CHECKING:
     from moe.library.extra import Extra
     from moe.library.track import Track
 
-__all__ = ["Album"]
+__all__ = ["Album", "AlbumError"]
 
 log = logging.getLogger("moe.album")
 
@@ -86,12 +85,10 @@ class Album(LibItem, SABase):
 
     Attributes:
         artist (str): AKA albumartist.
-        custom_fields set[str]: All custom fields. To add to this set, you should
-            implement the ``create_custom_album_fields`` hook.
         date (datetime.date): Album release date.
         disc_total (int): Number of discs in the album.
         extras (list[Extra]): Extra non-track files associated with the album.
-        path (Path): Filesystem path of the album directory.
+        path (pathlib.Path): Filesystem path of the album directory.
         title (str)
         tracks (list[Track]): Album's corresponding tracks.
         year (int): Album release year. Note, this field is read-only. Set ``date``

--- a/moe/library/extra.py
+++ b/moe/library/extra.py
@@ -12,9 +12,8 @@ from sqlalchemy.schema import ForeignKey
 
 import moe
 from moe import config
-from moe.library import SABase
 from moe.library.album import Album
-from moe.library.lib_item import LibItem, PathType
+from moe.library.lib_item import LibItem, PathType, SABase
 
 __all__ = ["Extra"]
 
@@ -71,10 +70,7 @@ class Extra(LibItem, SABase):
 
     Attributes:
         album_obj (Album): Album the extra file belongs to.
-        custom_fields set[str]: All custom fields. To add to this set, you should
-            implement the ``create_custom_extra_fields`` hook.
-        fields set[str]: All accessible extra fields.
-        path (Path): Filesystem path of the extra file.
+        path (pathlib.Path): Filesystem path of the extra file.
     """
 
     __tablename__ = "extra"

--- a/moe/library/lib_item.py
+++ b/moe/library/lib_item.py
@@ -8,6 +8,7 @@ import sqlalchemy
 import sqlalchemy as sa
 import sqlalchemy.event
 import sqlalchemy.orm
+from sqlalchemy.orm import declarative_base
 
 import moe
 from moe import config
@@ -15,6 +16,8 @@ from moe import config
 __all__ = ["LibItem", "LibraryError"]
 
 log = logging.getLogger("moe.lib_item")
+
+SABase = declarative_base()
 
 
 class LibraryError(Exception):
@@ -205,7 +208,7 @@ class LibItem:
     """Abstract base class for library items i.e. Albums, Extras, and Tracks."""
 
     @property
-    def path(self):
+    def path(self) -> Path:
         """A library item's filesystem path."""
         raise NotImplementedError
 

--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -15,9 +15,8 @@ from sqlalchemy.schema import ForeignKey, Table, UniqueConstraint
 
 import moe
 from moe import config
-from moe.library import SABase
 from moe.library.album import Album
-from moe.library.lib_item import LibItem, LibraryError, PathType
+from moe.library.lib_item import LibItem, LibraryError, PathType, SABase
 
 __all__ = ["Track", "TrackError"]
 
@@ -168,12 +167,9 @@ class Track(LibItem, SABase):
         albumartist (str)
         album_obj (Album): Corresponding Album object.
         artist (str)
-        custom_fields set[str]: All custom fields. To add to this set, you should
-            implement the ``create_custom_track_fields`` hook.
         date (datetime.date): Album release date.
         disc (int): Disc number the track is on.
         disc_total (int): Number of discs in the album.
-        fields set[str]: All accessible track fields.
         genre (str): String of all genres concatenated with ';'.
         genres (set[str]): Set of all genres.
         path (Path): Filesystem path of the track file.

--- a/moe/plugins/add/add_cli.py
+++ b/moe/plugins/add/add_cli.py
@@ -6,8 +6,7 @@ from pathlib import Path
 
 import moe
 import moe.cli
-from moe.library.album import Album, AlbumError
-from moe.library.track import Track, TrackError
+from moe.library import Album, AlbumError, Track, TrackError
 from moe.plugins import add as moe_add
 
 log = logging.getLogger("moe.cli.add")

--- a/moe/plugins/add/add_core.py
+++ b/moe/plugins/add/add_core.py
@@ -9,7 +9,7 @@ import pluggy
 
 import moe
 from moe import config
-from moe.library.lib_item import LibItem
+from moe.library import LibItem
 
 __all__ = ["AddAbortError", "AddError", "add_item"]
 

--- a/moe/plugins/duplicate/dup_cli.py
+++ b/moe/plugins/duplicate/dup_cli.py
@@ -4,7 +4,7 @@ import logging
 
 import moe
 import moe.cli
-from moe.library.lib_item import LibItem
+from moe.library import LibItem
 from moe.plugins.remove import remove_item
 from moe.util.cli import PromptChoice, choice_prompt, fmt_item_changes
 

--- a/moe/plugins/duplicate/dup_core.py
+++ b/moe/plugins/duplicate/dup_core.py
@@ -7,8 +7,7 @@ import sqlalchemy
 
 import moe
 from moe import config
-from moe.library.album import Album
-from moe.library.lib_item import LibItem
+from moe.library import Album, LibItem
 from moe.query import query
 
 __all__ = ["get_duplicates"]

--- a/moe/plugins/edit/edit_core.py
+++ b/moe/plugins/edit/edit_core.py
@@ -3,7 +3,7 @@
 import datetime
 import logging
 
-from moe.library.lib_item import LibItem
+from moe.library import LibItem
 
 __all__ = ["EditError", "edit_item"]
 

--- a/moe/plugins/info.py
+++ b/moe/plugins/info.py
@@ -14,10 +14,7 @@ from typing import Any
 import moe
 import moe.cli
 from moe import config
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import Album, Extra, LibItem, Track
 from moe.query import QueryError, query
 
 __all__: list[str] = []

--- a/moe/plugins/moe_import/import_cli.py
+++ b/moe/plugins/moe_import/import_cli.py
@@ -7,7 +7,7 @@ import pluggy
 import moe
 import moe.cli
 from moe import config
-from moe.library.album import Album
+from moe.library import Album
 from moe.util.cli import PromptChoice, choice_prompt, fmt_item_changes
 from moe.util.core import get_matching_tracks
 

--- a/moe/plugins/moe_import/import_core.py
+++ b/moe/plugins/moe_import/import_core.py
@@ -6,10 +6,7 @@ import pluggy
 
 import moe
 from moe import config
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import Album, Extra, LibItem, Track
 
 __all__ = ["import_album"]
 

--- a/moe/plugins/move/move_cli.py
+++ b/moe/plugins/move/move_cli.py
@@ -7,7 +7,7 @@ from typing import cast
 import sqlalchemy.orm
 
 import moe
-from moe.library.album import Album
+from moe.library import Album
 from moe.plugins import move as moe_move
 from moe.query import QueryError, query
 

--- a/moe/plugins/move/move_core.py
+++ b/moe/plugins/move/move_core.py
@@ -12,10 +12,7 @@ from unidecode import unidecode
 
 import moe
 from moe import config
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import Album, Extra, LibItem, Track
 
 __all__ = ["copy_item", "fmt_item_path", "move_item"]
 

--- a/moe/plugins/musicbrainz/mb_cli.py
+++ b/moe/plugins/musicbrainz/mb_cli.py
@@ -12,7 +12,7 @@ import questionary
 
 import moe
 import moe.cli
-from moe.library.album import Album
+from moe.library import Album
 from moe.plugins import moe_import
 from moe.plugins import musicbrainz as moe_mb
 from moe.util.cli import PromptChoice

--- a/moe/plugins/musicbrainz/mb_core.py
+++ b/moe/plugins/musicbrainz/mb_core.py
@@ -26,9 +26,7 @@ import pkg_resources
 
 import moe
 from moe import config
-from moe.library.album import Album
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import Album, LibItem, Track
 
 __all__ = [
     "MBAuthError",

--- a/moe/plugins/remove/rm_core.py
+++ b/moe/plugins/remove/rm_core.py
@@ -7,9 +7,7 @@ import sqlalchemy.exc
 from sqlalchemy.orm.session import Session
 
 from moe.config import MoeSession
-from moe.library.extra import Extra
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import Extra, LibItem, Track
 
 __all__ = ["remove_item"]
 

--- a/moe/plugins/write.py
+++ b/moe/plugins/write.py
@@ -7,8 +7,7 @@ import pluggy
 
 import moe
 from moe import config
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import LibItem, Track
 
 __all__ = ["write_tags"]
 

--- a/moe/query.py
+++ b/moe/query.py
@@ -10,10 +10,7 @@ import sqlalchemy.orm
 import sqlalchemy.sql.elements
 
 from moe.config import MoeSession
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import Album, Extra, LibItem, Track
 
 __all__: list[str] = ["QueryError", "query"]
 

--- a/moe/util/core/match.py
+++ b/moe/util/core/match.py
@@ -4,8 +4,7 @@ import difflib
 import logging
 from typing import Optional
 
-from moe.library.album import Album
-from moe.library.track import Track
+from moe.library import Album, Track
 
 log = logging.getLogger("moe")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,7 @@ import sqlalchemy.orm
 
 from moe import config
 from moe.config import Config, ExtraPlugin, MoeSession, session_factory
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.track import Track
+from moe.library import Album, Extra, Track
 from moe.plugins import write as moe_write
 
 __all__ = ["album_factory", "extra_factory", "track_factory"]

--- a/tests/library/test_album.py
+++ b/tests/library/test_album.py
@@ -6,8 +6,7 @@ import pytest
 
 import moe
 from moe.config import ExtraPlugin
-from moe.library.album import Album, AlbumError
-from moe.library.extra import Extra
+from moe.library import Album, AlbumError, Extra
 from moe.plugins import write as moe_write
 from tests.conftest import album_factory, track_factory
 

--- a/tests/library/test_extra.py
+++ b/tests/library/test_extra.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import moe
 from moe.config import ExtraPlugin
-from moe.library.extra import Extra
+from moe.library import Extra
 from tests.conftest import extra_factory
 
 

--- a/tests/library/test_lib_item.py
+++ b/tests/library/test_lib_item.py
@@ -5,9 +5,7 @@ import pytest
 
 import moe
 from moe.config import ExtraPlugin, MoeSession
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.track import Track
+from moe.library import Album, Extra, Track
 from tests.conftest import album_factory, extra_factory, track_factory
 
 

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -7,7 +7,8 @@ import pytest
 import moe
 import moe.plugins.write as moe_write
 from moe.config import ExtraPlugin
-from moe.library.track import Track, TrackError, _Genre
+from moe.library import Track, TrackError
+from moe.library.track import _Genre
 from moe.plugins.write import write_tags
 from tests.conftest import album_factory, extra_factory, track_factory
 

--- a/tests/plugins/add/test_add_core.py
+++ b/tests/plugins/add/test_add_core.py
@@ -5,10 +5,7 @@ import pytest
 import moe
 from moe import config
 from moe.config import ExtraPlugin
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.lib_item import LibItem
-from moe.library.track import Track
+from moe.library import Album, Extra, LibItem, Track
 from moe.plugins import add
 from tests.conftest import album_factory, extra_factory, track_factory
 

--- a/tests/plugins/duplicate/test_dup_cli.py
+++ b/tests/plugins/duplicate/test_dup_cli.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from moe import config
-from moe.library.track import Track
+from moe.library import Track
 from moe.plugins.duplicate import dup_cli
 from tests.conftest import track_factory
 

--- a/tests/plugins/duplicate/test_dup_core.py
+++ b/tests/plugins/duplicate/test_dup_core.py
@@ -6,9 +6,7 @@ import pytest
 
 import moe
 from moe.config import ExtraPlugin, MoeSession
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.track import Track
+from moe.library import Album, Extra, Track
 from moe.plugins.remove import remove_item
 from tests.conftest import album_factory, extra_factory, track_factory
 

--- a/tests/plugins/import/test_import_core.py
+++ b/tests/plugins/import/test_import_core.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import moe
 from moe import config
 from moe.config import ExtraPlugin
-from moe.library.album import Album
+from moe.library import Album
 from moe.plugins import moe_import
 from tests.conftest import album_factory, extra_factory, track_factory
 

--- a/tests/plugins/musicbrainz/resources/full_release.py
+++ b/tests/plugins/musicbrainz/resources/full_release.py
@@ -4,8 +4,7 @@
 import datetime
 from unittest.mock import MagicMock
 
-from moe.library.album import Album
-from moe.library.track import Track
+from moe.library import Album, Track
 
 # as returned by `musicbrainzngs.search_releases()`
 search = {

--- a/tests/plugins/musicbrainz/test_mb_core.py
+++ b/tests/plugins/musicbrainz/test_mb_core.py
@@ -8,7 +8,7 @@ import pytest
 import tests.plugins.musicbrainz.resources as mb_rsrc
 from moe import config
 from moe.config import ConfigValidationError
-from moe.library.track import Track
+from moe.library import Track
 from moe.plugins import musicbrainz as moe_mb
 from moe.plugins.musicbrainz.mb_core import MBAuthError
 from tests.conftest import album_factory, track_factory

--- a/tests/plugins/remove/test_rm_core.py
+++ b/tests/plugins/remove/test_rm_core.py
@@ -7,9 +7,7 @@ import sqlalchemy.orm
 
 import moe
 from moe.config import ExtraPlugin, MoeSession
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.track import Track
+from moe.library import Album, Extra, Track
 from moe.plugins import remove as moe_rm
 from tests.conftest import album_factory, extra_factory, track_factory
 

--- a/tests/plugins/test_write.py
+++ b/tests/plugins/test_write.py
@@ -8,7 +8,7 @@ import pytest
 
 import moe
 from moe import config
-from moe.library.track import Track
+from moe.library import Track
 from moe.plugins import write as moe_write
 from tests.conftest import album_factory, extra_factory, track_factory
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ import pytest
 import moe
 import moe.cli
 from moe import config
-from moe.library.track import Track
+from moe.library import Track
 from tests.conftest import track_factory
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,9 +4,7 @@
 import pytest
 
 import moe.query
-from moe.library.album import Album
-from moe.library.extra import Extra
-from moe.library.track import Track
+from moe.library import Album, Extra, Track
 from moe.query import QueryError, query
 from tests.conftest import album_factory, extra_factory, track_factory
 


### PR DESCRIPTION


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--154.org.readthedocs.build/en/154/

<!-- readthedocs-preview mrmoe end -->