### PR TITLE
fix: albums were not querying properly if they didn't contain tracks

### DIFF
--- a/moe/query.py
+++ b/moe/query.py
@@ -88,7 +88,9 @@ def query(query_str: str, query_type: str) -> list[LibItem]:
         raise QueryError(f"No query given.\n{HELP_STR}")
 
     if query_type == "album":
-        library_query = session.query(Album).join(Track)
+        library_query = session.query(Album)
+        if session.query(Track).first():
+            library_query = library_query.join(Track)
     elif query_type == "extra":
         library_query = session.query(Extra).join(Album).join(Track)
     else:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -224,9 +224,9 @@ class TestQueries:
 
         assert len(query("*", "album")) == 1
 
-    def test_missing_extras(self, tmp_session):
-        """Ensure albums without extras are still returned by a valid query."""
-        album = album_factory(num_extras=0)
+    def test_missing_extras_tracks(self, tmp_session):
+        """Ensure albums without extras or tracks."""
+        album = album_factory(num_extras=0, num_tracks=0)
 
         tmp_session.add(album)
         tmp_session.flush()


### PR DESCRIPTION
This may occur if you remove all tracks, and then attempt to remove the album after.

<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--158.org.readthedocs.build/en/158/

<!-- readthedocs-preview mrmoe end -->