### PR TITLE
fix: relative path error if album and file use non-relative hardlinks

### DIFF
--- a/moe/plugins/move/move_core.py
+++ b/moe/plugins/move/move_core.py
@@ -213,6 +213,7 @@ def _copy_file_item(item: Union[Extra, Track]):
     """Copies an extra or track to a destination as determined by the user config."""
     dest = fmt_item_path(item)
     if dest.exists() and dest.samefile(item.path):
+        item.path = dest
         return
 
     log.debug(f"Copying item. [{dest=}, {item=!r}]")
@@ -277,6 +278,7 @@ def _move_file_item(item: Union[Extra, Track]):
     """Moves an extra or track to a destination as determined by the user config."""
     dest = fmt_item_path(item)
     if dest.exists() and dest.samefile(item.path):
+        item.path = dest
         return
 
     log.debug(f"Moving item. [{dest=}, {item=!r}]")


### PR DESCRIPTION
Always sets an item's path to what Moe expects, even if technically two files are the same. This fixes an issue where a track and album may point to different library folders that technically are the same due to hardlinks.

<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview mrmoe end -->