### PR TITLE
feat(add): new import option to skip a single item

### DIFF
--- a/moe/plugins/add/add_cli.py
+++ b/moe/plugins/add/add_cli.py
@@ -8,10 +8,16 @@ import moe
 import moe.cli
 from moe.library import Album, AlbumError, Track, TrackError
 from moe.plugins import add as moe_add
+from moe.plugins.add.add_core import AddError
+from moe.util.cli import PromptChoice
 
 log = logging.getLogger("moe.cli.add")
 
 __all__: list[str] = []
+
+
+class SkipAdd(Exception):
+    """Used to skip adding a single item."""
 
 
 @moe.hookimpl
@@ -29,6 +35,22 @@ def add_command(cmd_parsers: argparse._SubParsersAction):
     add_parser.set_defaults(func=_parse_args)
 
 
+@moe.hookimpl
+def add_import_prompt_choice(prompt_choices: list[PromptChoice]):
+    """Adds the ``skip`` prompt choice to the import prompt."""
+    prompt_choices.append(
+        PromptChoice(title="Skip", shortcut_key="s", func=_skip_import)
+    )
+
+
+def _skip_import(
+    old_album: Album,
+    new_album: Album,
+):
+    """Skip adding/importing the current item."""
+    raise SkipAdd()
+
+
 def _parse_args(args: argparse.Namespace):
     """Parses the given commandline arguments.
 
@@ -44,25 +66,34 @@ def _parse_args(args: argparse.Namespace):
 
     error_count = 0
     for path in paths:
-        if path.is_file():
-            try:
-                track = Track.from_file(path)
-            except TrackError as err:
-                log.error(err)
-                error_count += 1
-            else:
-                moe_add.add_item(track)
-        elif path.is_dir():
-            try:
-                album = Album.from_dir(path)
-            except AlbumError as err:
-                log.error(err)
-                error_count += 1
-            else:
-                moe_add.add_item(album)
-        else:
-            log.error(f"Path not found. [{path=}]")
+        try:
+            _add_path(path)
+        except (AddError, AlbumError, TrackError) as err:
+            log.error(err)
             error_count += 1
+        except SkipAdd:
+            log.debug(f"Skipped adding item. [{path=}]")
 
     if error_count:
         raise SystemExit(1)
+
+
+def _add_path(path: Path):
+    """Adds an item to the library from a given path.
+
+    Args:
+        path: Path to add. Either a directory for an Album or a file for a Track.
+
+    Raises:
+        AddError: Path not found or other issue adding the item to the library.
+        AlbumError: Could not create an album from the given directory.
+        TrackError: Could not create a track from the given file.
+        SkipAdd: External program or user elected to skip adding the item.
+    """
+    if path.is_file():
+        moe_add.add_item(Track.from_file(path))
+    elif path.is_dir():
+        moe_add.add_item(Album.from_dir(path))
+    else:
+        log.error(f"Path not found. [{path=}]")
+        raise AddError("Path not found. [{path=}]")

--- a/moe/plugins/moe_import/import_cli.py
+++ b/moe/plugins/moe_import/import_cli.py
@@ -23,7 +23,7 @@ log = logging.getLogger("moe.cli.import")
 __all__ = ["AbortImport", "import_prompt"]
 
 
-class AbortImport(Exception):  # noqa: N818
+class AbortImport(Exception):
     """Used to abort the import process."""
 
 

--- a/moe/plugins/musicbrainz/mb_cli.py
+++ b/moe/plugins/musicbrainz/mb_cli.py
@@ -22,7 +22,7 @@ log = logging.getLogger("moe.cli.mb")
 
 @moe.hookimpl
 def add_import_prompt_choice(prompt_choices: list[PromptChoice]):
-    """Adds the ``apply`` and ``abort`` prompt choices to the user prompt."""
+    """Adds a choice to the import prompt to allow specifying a mb id."""
     prompt_choices.append(
         PromptChoice(title="Enter Musicbrainz ID", shortcut_key="m", func=_enter_id)
     )


### PR DESCRIPTION
Skipping the import process will skip adding the item to the library altogether.

<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--168.org.readthedocs.build/en/168/

<!-- readthedocs-preview mrmoe end -->