### PR TITLE
fix: sync_item not called with keyword arguments

### DIFF
--- a/moe/plugins/sync/sync_core.py
+++ b/moe/plugins/sync/sync_core.py
@@ -24,6 +24,6 @@ def sync_item(item: LibItem):
     """Syncs metadata from external sources and merges changes into ``item``."""
     log.debug(f"Syncing metadata. [{item=!r}]")
 
-    config.CONFIG.pm.hook.sync_metadata(item)
+    config.CONFIG.pm.hook.sync_metadata(item=item)
 
     log.debug(f"Synced metadata. [{item=!r}]")

--- a/tests/plugins/sync/test_sync_core.py
+++ b/tests/plugins/sync/test_sync_core.py
@@ -35,12 +35,12 @@ class TestHooks:
 
 
 class TestSyncItems:
-    """Test ``sync_items()``."""
+    """Test ``sync_item()``."""
 
-    def test_sync_items(self):
+    def test_sync_item(self):
         """Call the `sync_metadata` hook when syncing items."""
         track = track_factory()
 
         moe_sync.sync_item(track)
 
-        config.CONFIG.pm.hook.sync_metadata.assert_called_once_with(track)
+        config.CONFIG.pm.hook.sync_metadata.assert_called_once_with(item=track)


### PR DESCRIPTION


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--177.org.readthedocs.build/en/177/

<!-- readthedocs-preview mrmoe end -->