### PR TITLE
fix: tags now written to tracks if album fields changed

### DIFF
--- a/moe/plugins/write.py
+++ b/moe/plugins/write.py
@@ -7,7 +7,7 @@ import pluggy
 
 import moe
 from moe import config
-from moe.library import LibItem, Track
+from moe.library import Album, LibItem, Track
 
 __all__ = ["write_tags"]
 
@@ -62,10 +62,13 @@ def process_new_items(items: list[LibItem]):
 
 @moe.hookimpl
 def process_changed_items(items: list[LibItem]):
-    """Writes tags to any altered tracks in the library."""
+    """Writes tags to any altered tracks or albums in the library."""
     for item in items:
-        if isinstance(item, Track):
+        if isinstance(item, Track) and item.album_obj not in items:
             write_tags(item)
+        elif isinstance(item, Album):
+            for track in item.tracks:
+                write_tags(track)
 
 
 @moe.hookimpl(tryfirst=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,7 +236,7 @@ def extra_factory(
         Created extra.
     """
     album = album or album_factory(num_tracks=0, num_extras=0, exists=exists)
-    path = path or album.path / f"{random.randint(1,1000)}.txt"
+    path = path or album.path / f"{random.randint(1,10000)}.txt"
 
     extra = Extra(album=album, path=path, **kwargs)
 

--- a/tests/plugins/test_write.py
+++ b/tests/plugins/test_write.py
@@ -169,10 +169,12 @@ class TestProcessChangedItems:
         mock_write.assert_not_called()
 
     def test_process_album(self, mock_write):
-        """Any altered albums are ignored."""
-        config.CONFIG.pm.hook.process_changed_items(items=[album_factory()])
+        """Any altered albums should have their tracks written."""
+        album = album_factory()
+        config.CONFIG.pm.hook.process_changed_items(items=[album])
 
-        mock_write.assert_not_called()
+        for track in album.tracks:
+            mock_write.assert_any_call(track)
 
     def test_process_multiple_tracks(self, mock_write):
         """All altered tracks are written."""
@@ -183,3 +185,11 @@ class TestProcessChangedItems:
         for track in tracks:
             mock_write.assert_any_call(track)
         assert mock_write.call_count == 2
+
+    def test_dont_write_tracks_twice(self, mock_write):
+        """Don't write a track twice if it's album is also in `items`."""
+        track = track_factory()
+
+        config.CONFIG.pm.hook.process_changed_items(items=[track, track.album_obj])
+
+        mock_write.assert_called_once_with(track)


### PR DESCRIPTION
<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [ ] I have read the contributing guide in the documentation.

<!-- Description of the changes this pull request makes. -->
### Description
Previously, fields changes were only being written if a track had changed

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--197.org.readthedocs.build/en/197/

<!-- readthedocs-preview mrmoe end -->