### PR TITLE
feat: new album field - track_total

### DIFF
--- a/alembic/versions/32e9fea590b7_new_field_track_total.py
+++ b/alembic/versions/32e9fea590b7_new_field_track_total.py
@@ -1,0 +1,26 @@
+"""new field track_total.
+
+Revision ID: 32e9fea590b7
+Revises: eb8c7e20a080
+Create Date: 2022-10-12 13:59:57.620933
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "32e9fea590b7"
+down_revision = "eb8c7e20a080"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("album", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("track_total", sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("album", schema=None) as batch_op:
+        batch_op.drop_column("track_total")

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -44,6 +44,7 @@ Album Fields
     "original_year", "Year of the original release of the album", "3"
     "path", "Filesystem path of the album", ""
     "title", "Album title", ""
+    "track_total", "Number of tracks an album *should* have, not necessarily the number of tracks an album has in Moe.", ""
     "year", "Album release year", "3"
 
 ************

--- a/moe/library/album.py
+++ b/moe/library/album.py
@@ -97,6 +97,8 @@ class Album(LibItem, SABase):
             Set ``original_date`` instead.
         path (pathlib.Path): Filesystem path of the album directory.
         title (str)
+        track_total (int): Number of tracks that *should* be in the album. If an album
+            is missing tracks, then ``len(tracks) < track_total``.
         tracks (list[Track]): Album's corresponding tracks.
         year (int): Album release year. Note, this field is read-only. Set ``date``
             instead.
@@ -115,6 +117,7 @@ class Album(LibItem, SABase):
     original_date: datetime.date = cast(datetime.date, Column(Date, nullable=True))
     path: Path = cast(Path, Column(PathType, nullable=False, unique=True))
     title: str = cast(str, Column(String, nullable=False))
+    track_total: int = cast(int, Column(Integer, nullable=True))
     _custom_fields: dict[str, Any] = cast(
         dict[str, Any],
         Column(
@@ -229,6 +232,7 @@ class Album(LibItem, SABase):
             "original_date",
             "path",
             "title",
+            "track_total",
             "tracks",
         }.union(self._custom_fields)
 

--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -120,6 +120,7 @@ def read_custom_tags(
     album_fields["original_date"] = audio_file.original_date
     album_fields["path"] = track_path.parent
     album_fields["title"] = audio_file.album
+    album_fields["track_total"] = audio_file.tracktotal
 
     track_fields["artist"] = audio_file.artist
     track_fields["artists"] = set(audio_file.artists)

--- a/moe/plugins/musicbrainz/mb_core.py
+++ b/moe/plugins/musicbrainz/mb_core.py
@@ -141,6 +141,8 @@ def get_candidates(album: Album) -> list[CandidateAlbum]:
         search_criteria["reid"] = album.mb_album_id
     if album.media:
         search_criteria["format"] = album.media
+    if album.track_total:
+        search_criteria["tracks"] = album.track_total
 
     releases = musicbrainzngs.search_releases(limit=5, **search_criteria)
 
@@ -428,6 +430,7 @@ def _create_album(release: dict) -> Album:
                 mb_track_id=track["id"],
                 title=track["recording"]["title"],
             )
+    album.track_total = len(album.tracks)
 
     log.debug(f"Created album from musicbrainz release. [{album=!r}]")
     return album

--- a/moe/plugins/write.py
+++ b/moe/plugins/write.py
@@ -91,6 +91,7 @@ def write_custom_tags(track: Track):
     audio_file.original_date = track.album_obj.original_date
     audio_file.title = track.title
     audio_file.track = track.track_num
+    audio_file.tracktotal = track.album_obj.track_total
 
     audio_file.save()
 

--- a/moe/util/core/match.py
+++ b/moe/util/core/match.py
@@ -24,6 +24,7 @@ MATCH_ALBUM_FIELD_WEIGHTS = {
     "label": 0.1,
     "media": 0.4,
     "title": 0.9,
+    "track_total": 1.0,
 }  # how much to weigh matches of various fields
 
 MATCH_TRACK_FIELD_WEIGHTS = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,6 +297,7 @@ def album_factory(
         title=title,
         date=date,
         disc_total=num_discs,
+        track_total=num_tracks,
         **kwargs,
     )
     if custom_fields:

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -133,6 +133,7 @@ class TestFromFile:
         album.label = "RCA"
         album.media = "CD"
         album.original_date = datetime.date(2020, 1, 1)
+        album.track_total = 10
         write_tags(track)
 
         new_track = Track.from_file(track.path)
@@ -154,6 +155,7 @@ class TestFromFile:
         assert new_album.label == album.label
         assert new_album.media == album.media
         assert new_album.original_date == album.original_date
+        assert new_album.track_total == album.track_total
 
     def test_non_track_file(self):
         """Raise `TrackError` if the given path does not correspond to a track file."""

--- a/tests/plugins/musicbrainz/resources/full_release.py
+++ b/tests/plugins/musicbrainz/resources/full_release.py
@@ -1689,6 +1689,7 @@ def album() -> Album:
         original_date=datetime.date(2010, 1, 22),
         path=None,  # type: ignore
         mb_album_id="2fcfcaaa-6594-4291-b79f-2d354139e108",
+        track_total=2,
     )
 
 

--- a/tests/plugins/test_write.py
+++ b/tests/plugins/test_write.py
@@ -77,6 +77,7 @@ class TestWriteTags:
         original_date = datetime.date(1996, 1, 13)
         title = "What's Up"
         track_num = 3
+        track_total = 10
 
         track.album = album
         track.albumartist = albumartist
@@ -93,6 +94,7 @@ class TestWriteTags:
         track.album_obj.media = media
         track.title = title
         track.track_num = track_num
+        track.album_obj.track_total = track_total
 
         moe_write.write_tags(track)
 
@@ -115,6 +117,7 @@ class TestWriteTags:
         assert new_album.label == label
         assert new_album.media == media
         assert new_album.original_date == original_date
+        assert new_album.track_total == track_total
 
 
 @pytest.mark.usefixtures("_tmp_write_config")


### PR DESCRIPTION
<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [ ] I have read the contributing guide in the documentation.

<!-- Description of the changes this pull request makes. -->
### Description
New album field representing the total number of tracks belonging to an album. If an album is missing tracks, then len(album.tracks) < album.track_total

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--200.org.readthedocs.build/en/200/

<!-- readthedocs-preview mrmoe end -->