### PR TITLE
new MetaTrack and MetaAlbum classes

### DIFF
--- a/docs/developers/api/core.rst
+++ b/docs/developers/api/core.rst
@@ -27,7 +27,7 @@ Library
 
 .. automodule:: moe.library
    :members:
-   :exclude-members: cache_ok, path, year, genre, original_year
+   :exclude-members: cache_ok, path, year, catalog_num, genre, original_year
    :show-inheritance:
 
 

--- a/docs/developers/contributing.rst
+++ b/docs/developers/contributing.rst
@@ -133,9 +133,9 @@ New Field Checklist
 If adding a new field to Moe, the following checklist can help ensure you cover all your bases:
 
 #. Add the database column to the appropriate library class (``Album``, ``Extra``, or ``Track``).
-
+   * If the field represents metadata and does not deal with the filesystem, also add to the appropriate ``Meta`` class (``MetaAlbum`` or ``MetaTrack``).
    * If a multi-value field, add the non-plural equivalent property. See ``Track.genres`` and the accompanying single-value field, ``Track.genre`` for an example.
-   * Include documentation for the new field in the class docstring.
+   * Include documentation for the new field in the class docstring(s).
 
 #. Add to the item's ``fields`` method as necessary.
 #. Add code for reading the tag from a track file under ``Track.read_custom_tags``.

--- a/moe/library/album.py
+++ b/moe/library/album.py
@@ -3,7 +3,7 @@
 import datetime
 import logging
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
 
 import pluggy
 import sqlalchemy as sa
@@ -14,13 +14,13 @@ from sqlalchemy.orm import relationship
 
 import moe
 from moe import config
-from moe.library.lib_item import LibItem, LibraryError, PathType, SABase, SetType
+from moe.library.lib_item import LibItem, LibraryError, MetaLibItem, SABase, SetType
 
 if TYPE_CHECKING:
     from moe.library.extra import Extra
-    from moe.library.track import Track
+    from moe.library.track import MetaTrack, Track
 
-__all__ = ["Album", "AlbumError"]
+__all__ = ["Album", "AlbumError", "MetaAlbum"]
 
 log = logging.getLogger("moe.album")
 
@@ -74,54 +74,284 @@ class AlbumError(LibraryError):
     """Error performing some operation on an Album."""
 
 
+class MetaAlbum(MetaLibItem):
+    """A album containing only metadata.
+
+    It does not exist on the filesystem nor in the library. It can be used
+    to represent information about a album to later be merged into a full ``Album``
+    instance.
+
+    There are no guarantees about information present in a ``MetaAlbum`` object i.e.
+    all attributes may be ``None``.
+
+    Attributes:
+        artist (Optional[str]): AKA albumartist.
+        barcode (Optional[str]): UPC barcode.
+        catalog_num (Optional[str]): String of catalog numbers concatenated with ';'.
+        catalog_nums (Optional[set[str]]): Set of all catalog numbers.
+        country (Optional[str]): Country the album was released in
+            (two character identifier).
+        date (Optional[datetime.date]): Album release date.
+        disc_total (Optional[int]): Number of discs in the album.
+        label (Optional[str]): Album release label.
+        media (Optional[str]): Album release format (e.g. CD, Digital, etc.)
+        original_date (Optional[datetime.date]): Date of the original release of the
+            album.
+        title (Optional[str])
+        track_total (Optional[int]): Number of tracks that *should* be in the album.
+            If an album is missing tracks, then ``len(tracks) < track_total``.
+        tracks (list[Track]): Album's corresponding tracks.
+    """
+
+    def __init__(
+        self,
+        artist: Optional[str] = None,
+        barcode: Optional[str] = None,
+        catalog_nums: Optional[set[str]] = None,
+        country: Optional[str] = None,
+        date: Optional[datetime.date] = None,
+        disc_total: Optional[int] = None,
+        label: Optional[str] = None,
+        media: Optional[str] = None,
+        original_date: Optional[datetime.date] = None,
+        title: Optional[str] = None,
+        track_total: Optional[int] = None,
+        tracks: Optional[list["MetaTrack"]] = None,
+        **kwargs,
+    ):
+        """Creates a MetaAlbum object with any additional custom fields as kwargs."""
+        self._custom_fields = self._get_default_custom_fields()
+        self._custom_fields_set = set(self._custom_fields)
+
+        self.artist = artist
+        self.barcode = barcode
+        self.catalog_nums = catalog_nums
+        self.country = country
+        self.date = date
+        self.disc_total = disc_total
+        self.label = label
+        self.media = media
+        self.original_date = original_date
+        self.title = title
+        self.track_total = track_total
+
+        if not tracks:
+            self.tracks = []
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+        if config.CONFIG.settings.original_date and self.original_date:
+            self.date = self.original_date
+
+        log.debug(f"MetaAlbum created. [album={self!r}]")
+
+    @property
+    def catalog_num(self) -> Optional[str]:
+        """Returns a string of all catalog_nums concatenated with ';'."""
+        if self.catalog_nums is None:
+            return None
+
+        return ";".join(self.catalog_nums)
+
+    @catalog_num.setter
+    def catalog_num(self, catalog_num_str: Optional[str]):
+        """Sets a track's catalog_num from a string.
+
+        Args:
+            catalog_num_str: For more than one catalog_num, they should be split with
+                ';'.
+        """
+        if catalog_num_str is None:
+            self.catalog_nums = None
+        else:
+            self.catalog_nums = {
+                catalog_num.strip() for catalog_num in catalog_num_str.split(";")
+            }
+
+    @property
+    def fields(self) -> set[str]:
+        """Returns any editable album fields."""
+        return {
+            "artist",
+            "barcode",
+            "catalog_nums",
+            "country",
+            "date",
+            "disc_total",
+            "label",
+            "media",
+            "original_date",
+            "title",
+            "track_total",
+        }.union(self._custom_fields)
+
+    def get_track(self, track_num: int, disc: int = 1) -> Optional["MetaTrack"]:
+        """Gets a MetaTrack by its track number."""
+        return next(
+            (
+                track
+                for track in self.tracks
+                if track.track_num == track_num and track.disc == disc
+            ),
+            None,
+        )
+
+    def merge(self, other: "MetaAlbum", overwrite: bool = False) -> None:
+        """Merges another album into this one.
+
+        Args:
+            other: Other album to be merged with the current album.
+            overwrite: Whether or not to overwrite self if a conflict exists.
+        """
+        log.debug(f"Merging MetaAlbums. [album_a={self!r}, album_b={other!r}")
+
+        new_tracks: list["MetaTrack"] = []
+        for other_track in other.tracks:
+            conflict_track = None
+            if other_track.track_num and other_track.disc:
+                conflict_track = self.get_track(other_track.track_num, other_track.disc)
+            if conflict_track:
+                conflict_track.merge(other_track, overwrite)
+            else:
+                new_tracks.append(other_track)
+        self.tracks.extend(new_tracks)
+
+        for field in self.fields:
+            other_value = getattr(other, field)
+            self_value = getattr(self, field)
+            if other_value and (overwrite or (not overwrite and not self_value)):
+                setattr(self, field, other_value)
+
+        log.debug(
+            f"MetaAlbums merged. [album_a={self!r}, album_b={other!r}, {overwrite=!r}]"
+        )
+
+    def __eq__(self, other: "MetaAlbum") -> bool:
+        """Compares MetaAlbums by their fields."""
+        if type(self) != type(other):
+            return False
+
+        for field in self.fields:
+            if not hasattr(other, field) or (
+                getattr(self, field) != getattr(other, field)
+            ):
+                return False
+
+        return True
+
+    def __lt__(self, other: "MetaAlbum") -> bool:
+        """Sort an album based on its title, then artist, then date."""
+        if self.title == other.title:
+            if self.artist == other.artist:
+                if self.date is None:
+                    return False
+                if other.date is None:
+                    return True
+                return self.date < other.date
+
+            if self.artist is None:
+                return False
+            if other.artist is None:
+                return True
+            return self.artist < other.artist
+
+        if self.title is None:
+            return False
+        if other.title is None:
+            return True
+        return self.title < other.title
+
+    def __str__(self):
+        """String representation of an Album."""
+        album_str = f"{self.artist} - {self.title}"
+
+        if self.date:
+            album_str += f" ({self.date.year})"
+
+        return album_str
+
+    def __repr__(self):
+        """Represents an Album using its fields."""
+        field_reprs = []
+        for field in self.fields:
+            if hasattr(self, field):
+                field_reprs.append(f"{field}={getattr(self, field)!r}")
+        repr_str = "AlbumInfo(" + ", ".join(field_reprs)
+
+        custom_field_reprs = []
+        for custom_field, value in self._custom_fields.items():
+            custom_field_reprs.append(f"{custom_field}={value}")
+        if custom_field_reprs:
+            repr_str += ", custom_fields=[" + ", ".join(custom_field_reprs) + "]"
+
+        track_reprs = []
+        for track in sorted(self.tracks):
+            track_reprs.append(f"{track.disc}.{track.track_num} - {track.title}")
+        repr_str += ", tracks=[" + ", ".join(track_reprs) + "]"
+
+        repr_str += ")"
+        return repr_str
+
+    def _get_default_custom_fields(self) -> dict[str, Any]:
+        """Returns the default custom album fields."""
+        return {
+            field: default_val
+            for plugin_fields in config.CONFIG.pm.hook.create_custom_album_fields()
+            for field, default_val in plugin_fields.items()
+        }
+
+
 # Album generic, used for typing classmethod
 A = TypeVar("A", bound="Album")
 
 
-class Album(LibItem, SABase):
+class Album(LibItem, SABase, MetaAlbum):
     """An album is a collection of tracks and represents a specific album release.
 
     Albums also house any attributes that are shared by tracks e.g. albumartist.
 
     Attributes:
         artist (str): AKA albumartist.
-        barcode (str): UPC barcode.
-        catalog_nums (set[str]): Set of all catalog numbers.
-        country (str): Country the album was released in (two character identifier).
+        barcode (Optional[str]): UPC barcode.
+        catalog_nums (Optional[set[str]]): Set of all catalog numbers.
+        country (Optional[str]): Country the album was released in
+            (two character identifier).
         date (datetime.date): Album release date.
         disc_total (int): Number of discs in the album.
         extras (list[Extra]): Extra non-track files associated with the album.
-        label (str): Album release label.
-        media (str): Album release format (e.g. CD, Digital, etc.)
-        original_date (datetime.date): Date of the original release of the album.
-        original_year (int): Album original release year. Note, this field is read-only.
-            Set ``original_date`` instead.
+        label (Optional[str]): Album release label.
+        media (Optional[str]): Album release format (e.g. CD, Digital, etc.)
+        original_date (Optional[datetime.date]): Date of the original release of the
+            album.
+        original_year (Optional[int]): Album original release year. Note, this field is
+            read-only, set ``original_date`` instead.
         path (pathlib.Path): Filesystem path of the album directory.
         title (str)
-        track_total (int): Number of tracks that *should* be in the album. If an album
-            is missing tracks, then ``len(tracks) < track_total``.
+        track_total (Optional[int]): Number of tracks that *should* be in the album.
+            If an album is missing tracks, then ``len(tracks) < track_total``.
         tracks (list[Track]): Album's corresponding tracks.
-        year (int): Album release year. Note, this field is read-only. Set ``date``
+        year (int): Album release year. Note, this field is read-only, set ``date``
             instead.
     """
 
     __tablename__ = "album"
 
-    _id: int = cast(int, Column(Integer, primary_key=True))
     artist: str = cast(str, Column(String, nullable=False))
-    barcode: str = cast(str, Column(String, nullable=True))
+    barcode: Optional[str] = cast(Optional[str], Column(String, nullable=True))
     catalog_nums: Optional[set[str]] = cast(
         Optional[set[str]], MutableSet.as_mutable(Column(SetType, nullable=True))
     )
-    country: str = cast(str, Column(String, nullable=True))
+    country: Optional[str] = cast(Optional[str], Column(String, nullable=True))
     date: datetime.date = cast(datetime.date, Column(Date, nullable=False))
     disc_total: int = cast(int, Column(Integer, nullable=False, default=1))
-    label: str = cast(str, Column(String, nullable=True))
-    media: str = cast(str, Column(String, nullable=True))
-    original_date: datetime.date = cast(datetime.date, Column(Date, nullable=True))
-    path: Path = cast(Path, Column(PathType, nullable=False, unique=True))
+    label: Optional[str] = cast(Optional[str], Column(String, nullable=True))
+    media: Optional[str] = cast(Optional[str], Column(String, nullable=True))
+    original_date: Optional[datetime.date] = cast(
+        Optional[datetime.date], Column(Date, nullable=True)
+    )
     title: str = cast(str, Column(String, nullable=False))
-    track_total: int = cast(int, Column(Integer, nullable=True))
+    track_total: Optional[int] = cast(Optional[int], Column(Integer, nullable=True))
     _custom_fields: dict[str, Any] = cast(
         dict[str, Any],
         Column(
@@ -223,46 +453,8 @@ class Album(LibItem, SABase):
 
     @property
     def fields(self) -> set[str]:
-        """Returns any editable album fields."""
-        return {
-            "artist",
-            "barcode",
-            "catalog_nums",
-            "country",
-            "date",
-            "disc_total",
-            "extras",
-            "label",
-            "media",
-            "original_date",
-            "path",
-            "title",
-            "track_total",
-            "tracks",
-        }.union(self._custom_fields)
-
-    @property
-    def catalog_num(self) -> Optional[str]:
-        """Returns a string of all catalog_nums concatenated with ';'."""
-        if self.catalog_nums is None:
-            return None
-
-        return ";".join(self.catalog_nums)
-
-    @catalog_num.setter
-    def catalog_num(self, catalog_num_str: Optional[str]):
-        """Sets a track's catalog_num from a string.
-
-        Args:
-            catalog_num_str: For more than one catalog_num, they should be split with
-                ';'.
-        """
-        if catalog_num_str is None:
-            self.catalog_nums = None
-        else:
-            self.catalog_nums = {
-                catalog_num.strip() for catalog_num in catalog_num_str.split(";")
-            }
+        """Returns any editable, track-specific fields."""
+        return super().fields.union({"path"})
 
     def get_extra(self, rel_path: PurePath) -> Optional["Extra"]:
         """Gets an Extra by its path."""
@@ -272,14 +464,7 @@ class Album(LibItem, SABase):
 
     def get_track(self, track_num: int, disc: int = 1) -> Optional["Track"]:
         """Gets a Track by its track number."""
-        return next(
-            (
-                track
-                for track in self.tracks
-                if track.track_num == track_num and track.disc == disc
-            ),
-            None,
-        )
+        return cast("Track", super().get_track(track_num, disc))
 
     def is_unique(self, other: "Album") -> bool:
         """Returns whether an album is unique in the library from ``other``."""
@@ -294,7 +479,7 @@ class Album(LibItem, SABase):
 
         return True
 
-    def merge(self, other: "Album", overwrite: bool = False) -> None:
+    def merge(self, other: Union["Album", MetaAlbum], overwrite: bool = False) -> None:
         """Merges another album into this one.
 
         Args:
@@ -305,26 +490,28 @@ class Album(LibItem, SABase):
 
         new_tracks: list["Track"] = []
         for other_track in other.tracks:
-            conflict_track = self.get_track(other_track.track_num, other_track.disc)
+            conflict_track = None
+            if other_track.track_num and other_track.disc:
+                conflict_track = self.get_track(other_track.track_num, other_track.disc)
             if conflict_track:
                 conflict_track.merge(other_track, overwrite)
             else:
                 new_tracks.append(other_track)
         self.tracks.extend(new_tracks)
 
-        new_extras: list["Extra"] = []
-        for other_extra in other.extras:
-            conflict_extra = self.get_extra(other_extra.rel_path)
-            if conflict_extra:
-                conflict_extra.merge(other_extra, overwrite)
-            else:
-                new_extras.append(other_extra)
-        self.extras.extend(new_extras)
+        if isinstance(other, Album):
+            new_extras: list["Extra"] = []
+            for other_extra in other.extras:
+                conflict_extra = self.get_extra(other_extra.rel_path)
+                if conflict_extra:
+                    conflict_extra.merge(other_extra, overwrite)
+                else:
+                    new_extras.append(other_extra)
+            self.extras.extend(new_extras)
 
-        omit_fields = {"extras", "tracks"}
-        for field in self.fields - omit_fields:
-            other_value = getattr(other, field)
-            self_value = getattr(self, field)
+        for field in self.fields:
+            other_value = getattr(other, field, None)
+            self_value = getattr(self, field, None)
             if other_value and (overwrite or (not overwrite and not self_value)):
                 setattr(self, field, other_value)
 
@@ -333,8 +520,11 @@ class Album(LibItem, SABase):
         )
 
     @hybrid_property
-    def original_year(self) -> int:  # type: ignore
+    def original_year(self) -> Optional[int]:  # type: ignore
         """Gets an Album's year."""
+        if self.original_date is None:
+            return None
+
         return self.original_date.year
 
     @original_year.expression  # type: ignore
@@ -352,35 +542,10 @@ class Album(LibItem, SABase):
         """Returns a year at the sql level."""
         return sa.extract("year", cls.date)
 
-    def __eq__(self, other) -> bool:
-        """Compares Albums by their fields."""
-        if not isinstance(other, Album):
-            return False
-
-        omit_fields = {"extras", "tracks"}
-        for field in self.fields - omit_fields:
-            if not hasattr(other, field) or (
-                getattr(self, field) != getattr(other, field)
-            ):
-                return False
-
-        return True
-
-    def __lt__(self, other: "Album") -> bool:
-        """Sort an album based on its title, then artist, then date."""
-        if self.title == other.title:
-            if self.artist == other.artist:
-                return self.date < other.date
-
-            return self.artist < other.artist
-
-        return self.title < other.title
-
     def __repr__(self):
         """Represents an Album using its fields."""
         field_reprs = []
-        omit_fields = {"tracks", "extras"}
-        for field in self.fields - omit_fields:
+        for field in self.fields:
             if hasattr(self, field):
                 field_reprs.append(f"{field}={getattr(self, field)!r}")
         repr_str = "Album(" + ", ".join(field_reprs)
@@ -403,15 +568,3 @@ class Album(LibItem, SABase):
 
         repr_str += ")"
         return repr_str
-
-    def __str__(self):
-        """String representation of an Album."""
-        return f"{self.artist} - {self.title} ({self.year})"
-
-    def _get_default_custom_fields(self) -> dict[str, Any]:
-        """Returns the default custom album fields."""
-        return {
-            field: default_val
-            for plugin_fields in config.CONFIG.pm.hook.create_custom_album_fields()
-            for field, default_val in plugin_fields.items()
-        }

--- a/moe/library/extra.py
+++ b/moe/library/extra.py
@@ -13,7 +13,7 @@ from sqlalchemy.schema import ForeignKey
 import moe
 from moe import config
 from moe.library.album import Album
-from moe.library.lib_item import LibItem, PathType, SABase
+from moe.library.lib_item import LibItem, SABase
 
 __all__ = ["Extra"]
 
@@ -75,8 +75,6 @@ class Extra(LibItem, SABase):
 
     __tablename__ = "extra"
 
-    _id: int = cast(int, Column(Integer, primary_key=True))
-    path: Path = cast(Path, Column(PathType, nullable=False, unique=True))
     _custom_fields: dict[str, Any] = cast(
         dict[str, Any],
         Column(

--- a/moe/plugins/moe_import/import_core.py
+++ b/moe/plugins/moe_import/import_core.py
@@ -9,7 +9,7 @@ import pluggy
 
 import moe
 from moe import config
-from moe.library import Album, LibItem, Track
+from moe.library import Album, LibItem, MetaAlbum, Track
 
 __all__ = ["CandidateAlbum", "import_album"]
 
@@ -33,7 +33,7 @@ class CandidateAlbum:
         match_value_pct (str): ``match_value`` as a percentage.
     """
 
-    album: Album
+    album: MetaAlbum
     match_value: float
     source_str: str
     sub_header_info: list[str] = field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ markers = [
 
 [tool.pyright]
 exclude = [
-    "alembic",
+    "alembic", "tests"
 ]
 pythonPlatform = "All"
 

--- a/tests/plugins/musicbrainz/resources/full_release.py
+++ b/tests/plugins/musicbrainz/resources/full_release.py
@@ -4,7 +4,7 @@
 import datetime
 from unittest.mock import MagicMock
 
-from moe.library import Album, Track
+from moe.library import MetaAlbum, MetaTrack
 
 # as returned by `musicbrainzngs.search_releases()`
 search = {
@@ -1685,9 +1685,9 @@ release = {
 }
 
 
-def album() -> Album:
+def album() -> MetaAlbum:
     """Creates an album with the above release information."""
-    return Album(
+    album = MetaAlbum(
         artist="Kanye West",
         title="My Beautiful Dark Twisted Fantasy",
         barcode="602527474465",
@@ -1697,20 +1697,26 @@ def album() -> Album:
         label="Roc‐A‐Fella Records",
         media="CD",
         original_date=datetime.date(2010, 1, 22),
-        path=None,  # type: ignore
         mb_album_id="2fcfcaaa-6594-4291-b79f-2d354139e108",
         track_total=2,
+        disc_total=1,
     )
 
-
-def track() -> Track:
-    """Creates a track from the above release."""
-    return Track(
-        album=album(),
+    MetaTrack(
+        album=album,
         track_num=1,
-        path=None,  # type: ignore
         artist="Kanye West",
         title="Dark Fantasy",
-        mb_track_id="219e6b01-c962-355c-8a87-5d4ab3fc13bc",
         disc=1,
+        mb_track_id="219e6b01-c962-355c-8a87-5d4ab3fc13bc",
     )
+    MetaTrack(
+        album=album,
+        track_num=2,
+        artist="Kanye West",
+        title="Gorgeous",
+        disc=1,
+        mb_track_id="b3c6aa0a-6960-4db6-bf27-ed50de88309c",
+    )
+
+    return album

--- a/tests/util/core/test_match.py
+++ b/tests/util/core/test_match.py
@@ -115,10 +115,6 @@ class TestGetMatchingTracks:
 class TestMatchValue:
     """Test ``get_match_value()``."""
 
-    def test_different_type(self):
-        """Tracks cannot match with albums."""
-        assert get_match_value(album_factory(), track_factory()) == 0
-
     def test_same_album(self):
         """Albums with the same values for all used fields should be a perfect match."""
         album1 = album_factory()


### PR DESCRIPTION
These classes are used to represent albums and tracks containing only metadata i.e. they do not exist in the filesystem or database. This is useful when describing an album or track from an online source e.g. musicbrainz.

<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [ ] I have read the contributing guide in the documentation.

<!-- Description of the changes this pull request makes. -->
### Description

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--207.org.readthedocs.build/en/207/

<!-- readthedocs-preview mrmoe end -->