### PR TITLE
fix: use fork of mediafile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ moe = 'moe.cli:main'
 python = ">=3.9, <3.11"
 alembic = "^1.4.2"
 dynaconf = "^3.1.4"
-mediafile = {git = "https://github.com/jtpavlock/mediafile.git"}
+moe_mediafile = "^0.10.1"
 musicbrainzngs = "^0.7.1"
 pluggy = "^0.13.1"
 pyyaml = "^5.3.1"


### PR DESCRIPTION
Used to implement `None` values for lists if not present until merged into the main repository.

<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [ ] I have read the contributing guide in the documentation.

<!-- Description of the changes this pull request makes. -->
### Description

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--212.org.readthedocs.build/en/212/

<!-- readthedocs-preview mrmoe end -->