### PR TITLE
Show catalog number after label during import

### DIFF
--- a/moe/plugins/moe_import/import_cli.py
+++ b/moe/plugins/moe_import/import_cli.py
@@ -150,7 +150,7 @@ def candidate_prompt(new_album: Album, candidates: list[CandidateAlbum]):
 def _fmt_candidate_info(candidate: CandidateAlbum) -> str:
     """Formats a candidates info for the candidate prompt."""
     sub_header_values = []
-    for str_field in ["media", "country", "label"]:
+    for str_field in ["media", "country", "label", "catalog_num"]:
         if value := getattr(candidate.album, str_field):
             sub_header_values.append(value)
     sub_header_values.extend(candidate.sub_header_info)
@@ -259,7 +259,7 @@ def _fmt_album(new_album: Album, candidate: CandidateAlbum) -> Text:
         header_text.append_text(field_changes).append("\n")
 
     sub_header_text = Text()
-    for sub_header in ("media", "country", "label"):
+    for sub_header in ("media", "country", "label", "catalog_num"):
         field_changes = _fmt_field_changes(new_album, candidate.album, sub_header)
         if not field_changes:
             if getattr(new_album, sub_header):


### PR DESCRIPTION
<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [x] I have read the contributing guide in the documentation.

### Description

When looking through candidate albums from Musicbrainz I think it would be nice to print the catalog number beside the label to make sure it's a perfect match when you know the catalog number. This would also help in cases when one label has released the same album under multiple catalog numbers (reissues, different countries, etc.).

This PR prints the catalog number after the label for any album matches during the import process.

```
? Which album would you like to import? (Use shortcuts or arrow keys)
 » 1) [77.5%] ABBA - Voulez-Vous
              12" Vinyl | FR | Disques Vogue | M27506 | 1979
              Musicbrainz: 60843f73-f2b7-3dc7-92ee-8931d7085238

   2) [77.5%] ABBA - Voulez-Vous
              12" Vinyl | ES | Carnaby | TXS3146 | 1979
              Musicbrainz: b2503b44-c366-455b-8a51-689d6a7f6e64

   3) [77.5%] ABBA - Voulez-Vous
              12" Vinyl | GB | Epic | EPC 86086 | 1979
              Musicbrainz: e9aebab5-e314-4dbc-a9d3-24d3e7fe97e7

   4) [77.5%] ABBA - Voulez-Vous
              Cassette | US | Atlantic | CS 16000 | 1979
              Musicbrainz: 15024342-4d6f-4df4-a2cb-581b25ef4eef

   5) [76.3%] ABBA - Voulez‐Vous
              12" Vinyl | DE | Polydor | 2344 136 | 1979
              Musicbrainz: 716fec17-8e20-493c-8d93-56bec66f1fd6

   m) Enter Musicbrainz ID
   x) Abort
```

### Additional information

Not sure if this change is desirable though so I've marked this PR as a draft. Perhaps it would be slightly cleaner if there was no separator (`|`) between the label and catalog number, but this might be a small price to pay for the more generic interface.

Another option is to make the sub-header contents configurable. The default could then be `["media", "country", "label"]` and users who would like catalog numbers can add `catalog_num` or `catalog_nums` to it.

Happy to open an issue to discuss if this PR's direction is unclear.

I believe this change needs to be tested but I'm not too sure how to do this yet (hope tests run on draft PRs).

<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--216.org.readthedocs.build/en/216/

<!-- readthedocs-preview mrmoe end -->