### PR TITLE
Add `sample_rate` and `bit_depth` as `Track` properties

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -15,9 +15,11 @@ Track Fields
 * ``artist`` - track artist
 * ``artists`` - track artists [#f1]_
 * ``audio_format`` - aac, aiff, alac, ape, asf, dsf, flac, ogg, opus, mp3, mpc, wav, or wv [#f4]_
+* ``bit_depth`` - number of bits per sample in the audio encoding [#f4]_
 * ``disc`` - disc number
 * ``genre`` - genre [#f1]_
 * ``path`` - filesystem path of the track [#f3]_
+* ``sample_rate`` - sample rate of the track in Hz [#f4]_
 * ``title`` - track title
 * ``track_num`` - track number
 

--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -483,6 +483,23 @@ class Track(LibItem, SABase, MetaTrack):
         return mediafile.MediaFile(self.path).type
 
     @property
+    def sample_rate(self) -> int:
+        """Returns the sampling rate of the track.
+
+        The sampling rate is in Hertz (Hz) as an integer and zero when unavailable.
+        """
+        return mediafile.MediaFile(self.path).samplerate
+
+    @property
+    def bit_depth(self) -> int:
+        """Returns the number of bits per sample in the audio encoding.
+
+        The bit depth is an integer and zero when unavailable or when the file format
+        does not support bit depth.
+        """
+        return mediafile.MediaFile(self.path).bitdepth
+
+    @property
     def fields(self) -> set[str]:
         """Returns any editable, track-specific fields."""
         return super().fields.union({"path"})

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -272,6 +272,19 @@ class TestProperties:
 
         assert track.audio_format == "mp3"
 
+    def test_bit_depth(self):
+        """We can get the bit depth of a track."""
+        track = track_factory(exists=True)
+
+        # Bit depth is unavailable for MP3.
+        assert track.bit_depth == 0
+
+    def test_sample_rate(self):
+        """We can get the sample rate of a track."""
+        track = track_factory(exists=True)
+
+        assert track.sample_rate == 44100
+
 
 class TestListDuplicates:
     """List fields should not cause duplicate errors (just merge silently)."""


### PR DESCRIPTION
### Description

This PR adds `sample_rate` and `bit_depth` as `Track` properties following the discussion in #221 (actionable items 2 and 3).

I updated the docs and tests although MP3 bit depth is unavailable so `mediafile` returns 0 as expected.

I'm not sure if there is a convention on using underscores for property names since `track.albumartist` and `track.audio_format` both exist, but underscores seems to be more common and I find them more readable so I used `bit_depth` and `sample_rate`.

<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--228.org.readthedocs.build/en/228/

<!-- readthedocs-preview mrmoe end -->