### PR TITLE
fix: albumartist overwriting track artist

### DIFF
--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -179,14 +179,11 @@ class MetaTrack(MetaLibItem):
         album.tracks.append(self)
 
         self.track_num = track_num
-        self.artist = artist
+        self.artist = artist or self.album_obj.artist
         self.artists = artists
         self.disc = disc
         self.genres = genres
         self.title = title
-
-        # set default values
-        self.artist = self.album_obj.artist
 
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -379,11 +376,11 @@ class Track(LibItem, SABase, MetaTrack):
         self.title = title
         self.track_num = track_num
 
-        # set default values
-        self.artist = self.albumartist
-
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+        if self.artist is None:
+            self.artist = self.albumartist
 
         if not self.disc:
             self.disc = self._guess_disc()

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -91,6 +91,38 @@ class TestInit:
 
         assert new_track.disc == 1
 
+    def test_default_artist(self):
+        """Use the album artist if an artist is not given."""
+        album = album_factory(artist="use me")
+        track = track_factory(album=album, artist=None)
+
+        assert track.artist == "use me"
+
+    def test_use_given_artist(self):
+        """Don't use the album artist if an artist is given."""
+        album = album_factory(artist="dont use me")
+        track = track_factory(album=album, artist="use me")
+
+        assert track.artist == "use me"
+
+
+class TestMetaInit:
+    """Test MetaTrack initialization."""
+
+    def test_default_artist(self):
+        """Use the album artist if an artist is not given."""
+        album = MetaAlbum(artist="use me")
+        track = MetaTrack(album, 1, artist=None)
+
+        assert track.artist == "use me"
+
+    def test_use_given_artist(self):
+        """Don't use the album artist if an artist is given."""
+        album = MetaAlbum(artist="dont use me")
+        track = MetaTrack(album, 1, artist="use me")
+
+        assert track.artist == "use me"
+
 
 class TestAlbumSet:
     """Changing an album attribute will change the value for the current Album.

--- a/tests/plugins/musicbrainz/resources/full_release.py
+++ b/tests/plugins/musicbrainz/resources/full_release.py
@@ -1713,10 +1713,10 @@ def full_album() -> MetaAlbum:
     MetaTrack(
         album=album,
         track_num=2,
-        artist="Kanye West",
+        artist="Kanye West feat. Kid Cudi & Raekwon",
         title="Gorgeous",
         disc=1,
-        mb_track_id="b3c6aa0a-6960-4db6-bf27-ed50de88309c",
+        mb_track_id="d4cbaf03-b40a-352d-9461-eadbc5986fc0",
     )
 
     return album

--- a/tests/plugins/musicbrainz/resources/min_release.py
+++ b/tests/plugins/musicbrainz/resources/min_release.py
@@ -237,7 +237,7 @@ def min_album() -> MetaAlbum:
     MetaTrack(
         album=album,
         track_num=1,
-        artist="Tyler, the Creator",
+        artist="Tyler, the Creator & A$AP Rocky",
         title="POTATO SALAD",
         disc=1,
         mb_track_id="0cb6936a-19df-4067-b7ba-28d6c866d23f",

--- a/tests/plugins/musicbrainz/test_mb_core.py
+++ b/tests/plugins/musicbrainz/test_mb_core.py
@@ -323,6 +323,9 @@ class TestGetAlbumById:
             mb_album_id, includes=moe_mb.mb_core.RELEASE_INCLUDES
         )
         assert mb_album == mb_rsrc.full_album()
+        for track in mb_album.tracks:
+            assert track in mb_rsrc.full_album().tracks
+        assert len(mb_album.tracks) == len(mb_rsrc.full_album().tracks)
 
     def test_partial_date_year_mon(self, mock_mb_by_id, mb_config):
         """If given date is missing the day, default to 1."""
@@ -368,6 +371,9 @@ class TestGetAlbumById:
             mb_album_id, includes=moe_mb.mb_core.RELEASE_INCLUDES
         )
         assert mb_album == mb_rsrc.min_album()
+        for track in mb_album.tracks:
+            assert track in mb_rsrc.min_album().tracks
+        assert len(mb_album.tracks) == len(mb_rsrc.min_album().tracks)
 
 
 class TestGetCandidateByID:


### PR DESCRIPTION
<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [ ] I have read the contributing guide in the documentation.

<!-- Description of the changes this pull request makes. -->
### Description

A track's album artist was overwriting the artist field on initialization 

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--230.org.readthedocs.build/en/230/

<!-- readthedocs-preview mrmoe end -->