### PR TITLE
refactor!: rename `album_obj` reference to `album` in tracks and extras

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -4,14 +4,9 @@ Fields
 
 These are the fields Moe keeps track of for tracks, albums, and extras in your library.
 
-.. note::
-    Some track fields are actually on a per-album basis, and are just a mapping to the related album field e.g. ``albumartist`` or ``album``. These fields are exposed as track fields for convenience and due to convention.
-
 ************
 Track Fields
 ************
-* ``album`` - album title
-* ``albumartist`` - album artist
 * ``artist`` - track artist
 * ``artists`` - track artists [#f1]_
 * ``audio_format`` - aac, aiff, alac, ape, asf, dsf, flac, ogg, opus, mp3, mpc, wav, or wv [#f3]_ [#f4]_

--- a/docs/plugins/edit.rst
+++ b/docs/plugins/edit.rst
@@ -30,14 +30,6 @@ Positional Arguments
     .. note::
         If the specified field supports multiple values, you can separate those values with a semicolon e.g. ``genre=hip hop;pop``.
 
-    .. note::
-        Editing a track's album-related field is equivalent to editing the field directly through the album. For example, the following commands will both edit an album's artist.
-
-        .. code-block:: bash
-
-            moe edit [query] albumartist=2Pac
-            moe edit -a [query] artist=2Pac
-
 Optional Arguments
 ==================
 ``-h, --help``

--- a/moe/library/album.py
+++ b/moe/library/album.py
@@ -358,13 +358,13 @@ class Album(LibItem, SABase, MetaAlbum):
 
     tracks: list["Track"] = relationship(
         "Track",
-        back_populates="album_obj",
+        back_populates="album",
         cascade="all, delete-orphan",
         collection_class=list,
     )
     extras: list["Extra"] = relationship(
         "Extra",
-        back_populates="album_obj",
+        back_populates="album",
         cascade="all, delete-orphan",
         collection_class=list,
     )
@@ -435,7 +435,7 @@ class Album(LibItem, SABase, MetaAlbum):
                 extra_paths.append(file_path)
             else:
                 if not album:
-                    album = track.album_obj
+                    album = track.album
 
         if not album:
             raise AlbumError(f"No tracks found in album directory. [dir={album_path}]")

--- a/moe/plugins/duplicate/dup_cli.py
+++ b/moe/plugins/duplicate/dup_cli.py
@@ -113,14 +113,12 @@ def _fmt_item_text(
         header = Text(f"{item}", justify="center")
         omit_fields = {"extras", "tracks", "year"}
     elif isinstance(item, Extra):
-        header = Text(f"{item.rel_path}\n{item.album_obj}", justify="center")
-        omit_fields = {"album_obj", "rel_path", "path"}
+        header = Text(f"{item.rel_path}\n{item.album}", justify="center")
+        omit_fields = {"album", "rel_path", "path"}
     else:
-        header = Text(f"{item.title}\n{item.album_obj}", justify="center")
+        header = Text(f"{item.title}\n{item.album}", justify="center")
         omit_fields = {
             "album",
-            "albumartist",
-            "album_obj",
             "date",
             "disc_total",
             "genre",

--- a/moe/plugins/list.py
+++ b/moe/plugins/list.py
@@ -131,7 +131,7 @@ def _fmt_extra_info(extra: Extra) -> str:
 def _fmt_track_info(track: Track) -> str:
     """Formats a track's information for display."""
     base_dict = OrderedDict(sorted(_get_base_dict(track).items()))
-    base_dict.pop("album_obj", None)
+    base_dict.pop("album", None)
 
     return "\n".join(
         f"{field}: {value}"

--- a/moe/plugins/moe_import/import_core.py
+++ b/moe/plugins/moe_import/import_core.py
@@ -102,7 +102,7 @@ def pre_add(item: LibItem):
     if isinstance(item, Album):
         album = item
     elif isinstance(item, Track):
-        album = item.album_obj
+        album = item.album
     else:
         return
 

--- a/moe/plugins/move/move_core.py
+++ b/moe/plugins/move/move_core.py
@@ -79,7 +79,7 @@ def create_path_template_func() -> list[Callable]:
 
 def e_unique(extra: Extra) -> str:
     """Returns a unique filename for an extra within its album."""
-    extra_names = [album_extra.path.name for album_extra in extra.album_obj.extras]
+    extra_names = [album_extra.path.name for album_extra in extra.album.extras]
 
     if (name_count := extra_names.count(extra.path.name)) > 1:
         return extra.path.stem + f" ({name_count - 1})" + extra.path.suffix
@@ -130,7 +130,7 @@ def _fmt_album_path(album: Album, lib_path: Path) -> Path:
 
 def _fmt_extra_path(extra: Extra, lib_path: Path) -> Path:
     """Returns a formatted extra path according to the user configuration."""
-    album_path = _fmt_album_path(extra.album_obj, lib_path)
+    album_path = _fmt_album_path(extra.album, lib_path)
     extra_path = _eval_path_template(config.CONFIG.settings.move.extra_path, extra)
 
     return album_path / extra_path
@@ -138,7 +138,7 @@ def _fmt_extra_path(extra: Extra, lib_path: Path) -> Path:
 
 def _fmt_track_path(track: Track, lib_path: Path) -> Path:
     """Returns a formatted track path according to the user configuration."""
-    album_path = _fmt_album_path(track.album_obj, lib_path)
+    album_path = _fmt_album_path(track.album, lib_path)
     track_path = _eval_path_template(config.CONFIG.settings.move.track_path, track)
 
     return album_path / track_path
@@ -194,10 +194,10 @@ def _lazy_fstr_item(template: str, lib_item: LibItem) -> str:
         album = lib_item  # noqa: F841
     elif isinstance(lib_item, Track):
         track = lib_item  # noqa: F841
-        album = track.album_obj
+        album = track.album
     elif isinstance(lib_item, Extra):
         extra = lib_item  # noqa: F841
-        album = extra.album_obj  # noqa: F841
+        album = extra.album  # noqa: F841
     else:
         raise NotImplementedError
 

--- a/moe/plugins/musicbrainz/mb_cli.py
+++ b/moe/plugins/musicbrainz/mb_cli.py
@@ -64,7 +64,7 @@ def _parse_args(args: argparse.Namespace):
     for item in items:
         release_id: Optional[str] = None
         if isinstance(item, (Extra, Track)):
-            release_id = item.album_obj.mb_album_id
+            release_id = item.album.mb_album_id
         elif isinstance(item, Album):
             release_id = item.mb_album_id
 

--- a/moe/plugins/musicbrainz/mb_core.py
+++ b/moe/plugins/musicbrainz/mb_core.py
@@ -215,7 +215,7 @@ def sync_metadata(item: LibItem):
     elif isinstance(item, Track) and hasattr(item, "mb_track_id"):
         item = cast(Track, item)
         item.merge(
-            get_track_by_id(item.mb_track_id, item.album_obj.mb_album_id),
+            get_track_by_id(item.mb_track_id, item.album.mb_album_id),
             overwrite=True,
         )
 
@@ -225,7 +225,7 @@ def write_custom_tags(track: Track):
     """Write musicbrainz ID fields as tags."""
     audio_file = mediafile.MediaFile(track.path)
 
-    audio_file.mb_albumid = track.album_obj.mb_album_id
+    audio_file.mb_albumid = track.album.mb_album_id
     audio_file.mb_releasetrackid = track.mb_track_id
 
     audio_file.save()

--- a/moe/plugins/remove/rm_core.py
+++ b/moe/plugins/remove/rm_core.py
@@ -25,7 +25,7 @@ def remove_item(item: LibItem):
     elif insp.pending:
         session.expunge(item)
         if isinstance(item, (Track, Extra)):
-            item.album_obj = None  # type: ignore
+            item.album = None  # type: ignore
 
     try:
         session.flush()

--- a/moe/plugins/write.py
+++ b/moe/plugins/write.py
@@ -64,7 +64,7 @@ def process_new_items(items: list[LibItem]):
 def process_changed_items(items: list[LibItem]):
     """Writes tags to any altered tracks or albums in the library."""
     for item in items:
-        if isinstance(item, Track) and item.album_obj not in items:
+        if isinstance(item, Track) and item.album not in items:
             write_tags(item)
         elif isinstance(item, Album):
             for track in item.tracks:
@@ -76,23 +76,23 @@ def write_custom_tags(track: Track):
     """Writes all internally tracked tags to the track."""
     audio_file = mediafile.MediaFile(track.path)
 
-    audio_file.album = track.album
-    audio_file.albumartist = track.albumartist
+    audio_file.album = track.album.title
+    audio_file.albumartist = track.album.artist
     audio_file.artist = track.artist
     audio_file.artists = track.artists
-    audio_file.barcode = track.album_obj.barcode
-    audio_file.catalognums = track.album_obj.catalog_nums
-    audio_file.country = track.album_obj.country
-    audio_file.date = track.album_obj.date
+    audio_file.barcode = track.album.barcode
+    audio_file.catalognums = track.album.catalog_nums
+    audio_file.country = track.album.country
+    audio_file.date = track.album.date
     audio_file.disc = track.disc
-    audio_file.disctotal = track.album_obj.disc_total
+    audio_file.disctotal = track.album.disc_total
     audio_file.genres = track.genres
-    audio_file.label = track.album_obj.label
-    audio_file.media = track.album_obj.media
-    audio_file.original_date = track.album_obj.original_date
+    audio_file.label = track.album.label
+    audio_file.media = track.album.media
+    audio_file.original_date = track.album.original_date
     audio_file.title = track.title
     audio_file.track = track.track_num
-    audio_file.tracktotal = track.album_obj.track_total
+    audio_file.tracktotal = track.album.track_total
 
     audio_file.save()
 

--- a/tests/plugins/add/test_add_cli.py
+++ b/tests/plugins/add/test_add_cli.py
@@ -147,7 +147,7 @@ class TestCommand:
         """Extra files are added as tracks."""
         extra = extra_factory(exists=True)
         cli_args = ["add", "-a", "*", str(extra.path)]
-        mock_query.return_value = [extra.album_obj]
+        mock_query.return_value = [extra.album]
 
         moe.cli.main(cli_args)
 

--- a/tests/plugins/import/test_import_cli.py
+++ b/tests/plugins/import/test_import_cli.py
@@ -252,7 +252,7 @@ class TestAddImportPromptChoice:
         for new_track in candidate.album.tracks:
             new_track.path = None  # type: ignore
         for new_extra in candidate.album.extras:
-            new_extra.album_obj = None  # type: ignore
+            new_extra.album = None  # type: ignore
 
         mock_choice = PromptChoice("mock", "m", moe_import.import_cli._apply_changes)
         with patch(

--- a/tests/plugins/import/test_import_core.py
+++ b/tests/plugins/import/test_import_core.py
@@ -92,7 +92,7 @@ class TestPreAdd:
         ) as mock_import:
             config.CONFIG.pm.hook.pre_add(item=track)
 
-        mock_import.assert_called_once_with(track.album_obj)
+        mock_import.assert_called_once_with(track.album)
 
     def test_pre_add_extra(self, tmp_config):
         """Don't try to import an Extra."""

--- a/tests/plugins/move/test_move_core.py
+++ b/tests/plugins/move/test_move_core.py
@@ -128,7 +128,7 @@ class TestFmtItemPath:
         extra = extra_factory()
         extra_path = moe_move.fmt_item_path(extra)
 
-        assert extra_path.is_relative_to(moe_move.fmt_item_path(extra.album_obj))
+        assert extra_path.is_relative_to(moe_move.fmt_item_path(extra.album))
 
     @pytest.mark.usefixtures("_tmp_move_config")
     def test_track_relative_to_album(self):
@@ -136,7 +136,7 @@ class TestFmtItemPath:
         track = track_factory()
         track_path = moe_move.fmt_item_path(track)
 
-        assert track_path.is_relative_to(track.album_obj.path)
+        assert track_path.is_relative_to(track.album.path)
 
     def test_asciify_paths(self, tmp_config):
         """Paths should not contain unicode characters if `asciify_paths` is true."""

--- a/tests/plugins/musicbrainz/test_mb_cli.py
+++ b/tests/plugins/musicbrainz/test_mb_cli.py
@@ -39,7 +39,7 @@ class TestCollectionCommand:
         """Tracks associated album's are used."""
         cli_args = ["mbcol", "*"]
         track = track_factory()
-        track.album_obj.mb_album_id = "123"
+        track.album.mb_album_id = "123"
         mock_query.return_value = [track]
 
         with patch(
@@ -54,7 +54,7 @@ class TestCollectionCommand:
         """Extras associated album's are used."""
         cli_args = ["mbcol", "-e", "*"]
         extra = extra_factory()
-        extra.album_obj.mb_album_id = "123"
+        extra.album.mb_album_id = "123"
         mock_query.return_value = [extra]
 
         with patch(
@@ -83,7 +83,7 @@ class TestCollectionCommand:
         """Releases are removed from a collection if `--remove` option used."""
         cli_args = ["mbcol", "--remove", "*"]
         track = track_factory()
-        track.album_obj.mb_album_id = "123"
+        track.album.mb_album_id = "123"
         mock_query.return_value = [track]
 
         with patch(
@@ -98,7 +98,7 @@ class TestCollectionCommand:
         """Releases are added to a collection if `--add` option used."""
         cli_args = ["mbcol", "--add", "*"]
         track = track_factory()
-        track.album_obj.mb_album_id = "123"
+        track.album.mb_album_id = "123"
         mock_query.return_value = [track]
 
         with patch(

--- a/tests/plugins/musicbrainz/test_mb_core.py
+++ b/tests/plugins/musicbrainz/test_mb_core.py
@@ -292,7 +292,7 @@ class TestSyncMetadata:
             config.CONFIG.pm.hook.sync_metadata(item=old_track)
 
         mock_id.assert_called_once_with(
-            old_track.mb_track_id, old_track.album_obj.mb_album_id
+            old_track.mb_track_id, old_track.album.mb_album_id
         )
         assert old_track.title == "synced"
 
@@ -453,7 +453,7 @@ class TestCustomFields:
 
         new_track = Track.from_file(track.path)
 
-        assert new_track.album_obj.mb_album_id == "album id"
+        assert new_track.album.mb_album_id == "album id"
         assert new_track.mb_track_id == "track id"
 
 

--- a/tests/plugins/test_write.py
+++ b/tests/plugins/test_write.py
@@ -62,8 +62,6 @@ class TestWriteTags:
         """We can write track changes to the file."""
         tmp_config()
         track = track_factory(exists=True)
-        album = "Bigger, Better, Faster, More!"
-        albumartist = "4 Non Blondes"
         artist = "4 Non Blondes"
         artists = {"4 Non Blondes", "Me"}
         barcode = "1234"
@@ -80,31 +78,27 @@ class TestWriteTags:
         track_num = 3
         track_total = 10
 
-        track.album = album
-        track.albumartist = albumartist
         track.artist = artist
         track.artists = artists
-        track.album_obj.barcode = barcode
-        track.album_obj.catalog_nums = catalog_nums
-        track.album_obj.country = country
-        track.album_obj.date = date
-        track.album_obj.original_date = original_date
+        track.album.barcode = barcode
+        track.album.catalog_nums = catalog_nums
+        track.album.country = country
+        track.album.date = date
+        track.album.original_date = original_date
         track.disc = disc
-        track.album_obj.disc_total = disc_total
+        track.album.disc_total = disc_total
         track.genres = genres
-        track.album_obj.label = label
-        track.album_obj.media = media
+        track.album.label = label
+        track.album.media = media
         track.title = title
         track.track_num = track_num
-        track.album_obj.track_total = track_total
+        track.album.track_total = track_total
 
         moe_write.write_tags(track)
 
         new_track = Track.from_file(track.path)
-        new_album = new_track.album_obj
+        new_album = new_track.album
 
-        assert new_track.album == album
-        assert new_track.albumartist == albumartist
         assert new_track.artist == artist
         assert new_track.artists == artists
         assert new_track.disc == disc
@@ -196,6 +190,6 @@ class TestProcessChangedItems:
         """Don't write a track twice if it's album is also in `items`."""
         track = track_factory()
 
-        config.CONFIG.pm.hook.process_changed_items(items=[track, track.album_obj])
+        config.CONFIG.pm.hook.process_changed_items(items=[track, track.album])
 
         mock_write.assert_called_once_with(track)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -137,7 +137,7 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query(f"a:year:{album.year} album:{album.title}", "album")
+        assert query(f"a:year:{album.year} a:title:{album.title}", "album")
 
     def test_regex(self, tmp_session):
         """Queries can use regular expression matching."""
@@ -184,18 +184,6 @@ class TestQueries:
         tmp_session.flush()
 
         assert query("a:title::tmp", "album")
-
-    def test_track_album_field(self, tmp_session):
-        """We should be able to query tracks that match album-related fields.
-
-        These fields belong to the Album table and thus aren't normally exposed
-        through a track.
-        """
-        album = album_factory()
-        tmp_session.add(album)
-        tmp_session.flush()
-
-        assert query(f"'album:{album.title}'", "track")
 
     def test_like_query(self, tmp_session):
         """Test sql LIKE queries. '%' and '_' are wildcard characters."""

--- a/tests/util/core/test_match.py
+++ b/tests/util/core/test_match.py
@@ -52,7 +52,7 @@ class TestGetMatchingTracks:
         assert track1.track_num != track2.track_num
 
         track_matches = get_matching_tracks(
-            track1.album_obj, track2.album_obj, match_threshold=0
+            track1.album, track2.album, match_threshold=0
         )
 
         for track_match in track_matches:
@@ -84,11 +84,11 @@ class TestGetMatchingTracks:
         """Any track should not have more than one match."""
         track1 = track_factory(track_num=1)
         track2 = track_factory(track_num=2)
-        track1.album_obj = track2.album_obj
+        track1.album = track2.album
 
         track3 = track_factory(track_num=3)
         track4 = track_factory(track_num=4)
-        track3.album_obj = track4.album_obj
+        track3.album = track4.album
 
         track3.title = "not a match"
         assert track2.title != track3.title
@@ -101,7 +101,7 @@ class TestGetMatchingTracks:
             return 0
 
         with patch("moe.util.core.match.get_match_value", wraps=mock_get_value):
-            track_matches = get_matching_tracks(track1.album_obj, track3.album_obj)
+            track_matches = get_matching_tracks(track1.album, track3.album)
 
         album1_tracks = [track_match[0] for track_match in track_matches]
         assert album1_tracks.count(track1) == 1


### PR DESCRIPTION
`track.album` now refers to the actual album object (renamed from `track.album_obj`) and `track.albumartist` has been removed. Similarly, `extra.album_obj` has been renamed to `extra.album`.

The original idea was that `track.album` was a string that referred to an album's title, while `track.album_obj` was the actual album object itself. `track.album` and `track.albumartist` were "mapped" attributes of an album directly exposed in the track API due to convention. However, these mapped attributes are not first-class attributes as far as sqlalchemy is concerned, and thus have additional issues and considerations compared to normal attributes. Ultimately, I decided these mapped attributes are not worth the headache.


<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--242.org.readthedocs.build/en/242/

<!-- readthedocs-preview mrmoe end -->