### PR TITLE
refactor!: custom fields now require dictionary access

### DIFF
--- a/alembic/versions/ab5db9861d30_rename_custom_fields.py
+++ b/alembic/versions/ab5db9861d30_rename_custom_fields.py
@@ -1,0 +1,36 @@
+"""Rename custom fields.
+
+Revision ID: ab5db9861d30
+Revises: 880c5a2d80ed
+Create Date: 2022-12-11 15:24:10.227924
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ab5db9861d30"
+down_revision = "880c5a2d80ed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("album", schema=None) as batch_op:
+        batch_op.alter_column("_custom_fields", new_column_name="custom")
+
+    with op.batch_alter_table("extra", schema=None) as batch_op:
+        batch_op.alter_column("_custom_fields", new_column_name="custom")
+
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.alter_column("_custom_fields", new_column_name="custom")
+
+
+def downgrade():
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.alter_column("custom", new_column_name="_custom_fields")
+
+    with op.batch_alter_table("extra", schema=None) as batch_op:
+        batch_op.alter_column("custom", new_column_name="_custom_fields")
+
+    with op.batch_alter_table("album", schema=None) as batch_op:
+        batch_op.alter_column("custom", new_column_name="_custom_fields")

--- a/docs/developers/api/core.rst
+++ b/docs/developers/api/core.rst
@@ -28,7 +28,7 @@ Library
 
 .. automodule:: moe.library
    :members:
-   :exclude-members: cache_ok, path
+   :exclude-members: cache_ok, path, custom
    :show-inheritance:
    :special-members: __init__
 

--- a/moe/library/lib_item.py
+++ b/moe/library/lib_item.py
@@ -268,19 +268,7 @@ class MetaLibItem:
     These objects do not exist on the filesystem nor in the library.
     """
 
-    _custom_fields = {}
-    _custom_fields_set = None
-
-    @property
-    def custom_fields(self) -> set[str]:
-        """Returns the custom fields of an item."""
-        if self._custom_fields_set is None:
-            object.__setattr__(
-                self, "_custom_fields_set", set(self._get_default_custom_fields())
-            )
-
-        assert self._custom_fields_set is not None
-        return self._custom_fields_set
+    custom = {}
 
     def _get_default_custom_fields(self) -> dict[str, Any]:
         """Returns the default custom fields of an item."""
@@ -291,19 +279,9 @@ class MetaLibItem:
         """Returns the editable fields of an item."""
         raise NotImplementedError
 
-    def __getattr__(self, name: str):
-        """See if ``name`` is a custom field."""
-        if name in self.custom_fields:
-            return self._custom_fields[name]
-        else:
-            raise AttributeError from None
-
-    def __setattr__(self, name, value):
-        """Set custom custom_fields if a valid key."""
-        if name in self.custom_fields:
-            self._custom_fields[name] = value
-        else:
-            super().__setattr__(name, value)
+    def merge(self, other, overwrite: bool = False) -> None:
+        """Merges another item into this one."""
+        raise NotImplementedError
 
     def __lt__(self, other):
         """Library items implement the `lt` magic method to allow sorting."""

--- a/moe/plugins/edit/edit_core.py
+++ b/moe/plugins/edit/edit_core.py
@@ -36,8 +36,8 @@ def edit_item(item: LibItem, field: str, value: str):  # noqa: C901
     try:
         attr = getattr(item.__class__, field)
     except AttributeError as a_err:
-        if field in item._custom_fields:
-            setattr(item, field, value)
+        if field in item.custom:
+            item.custom[field] = value
             return
 
         raise EditError(f"Invalid field given. [{field=!r}]") from a_err

--- a/moe/plugins/list.py
+++ b/moe/plugins/list.py
@@ -153,9 +153,13 @@ def _get_base_dict(item: LibItem) -> dict[str, Any]:
         Returns a dict representation of an Item in the form { attribute: value }.
     """
     item_dict = {}
-    for attr in sorted(item.fields):
+    for attr in item.fields:
         value = getattr(item, attr)
         if value:
             item_dict[attr] = value
+
+    for custom_field, value in item.custom.items():
+        if value:
+            item_dict[custom_field] = value
 
     return item_dict

--- a/moe/plugins/musicbrainz/mb_cli.py
+++ b/moe/plugins/musicbrainz/mb_cli.py
@@ -64,9 +64,9 @@ def _parse_args(args: argparse.Namespace):
     for item in items:
         release_id: Optional[str] = None
         if isinstance(item, (Extra, Track)):
-            release_id = item.album.mb_album_id
+            release_id = item.album.custom.get("mb_album_id")
         elif isinstance(item, Album):
-            release_id = item.mb_album_id
+            release_id = item.custom.get("mb_album_id")
 
         if release_id:
             releases.add(release_id)

--- a/moe/query.py
+++ b/moe/query.py
@@ -234,9 +234,9 @@ def _getattr(item_class: Type[LibItem], field: str):
         attr = getattr(item_class, field)
     except AttributeError:
         # assume custom field
-        custom_func = sa.func.json_each(
-            item_class._custom_fields, f"$.{field}"
-        ).table_valued("value", joins_implicitly=True)
+        custom_func = sa.func.json_each(item_class.custom, f"$.{field}").table_valued(
+            "value", joins_implicitly=True
+        )
 
         return custom_func.c.value
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import textwrap
 from pathlib import Path
-from typing import Any, Callable, Iterator, Optional
+from typing import Callable, Iterator, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -151,7 +151,6 @@ def track_factory(
     album: Optional[Album] = None,
     exists: bool = False,
     dup_track: Optional[Track] = None,
-    custom_fields: Optional[dict[str, Any]] = None,
     **kwargs,
 ):
     """Creates a track.
@@ -161,7 +160,6 @@ def track_factory(
         exists: Whether the track should exist on the filesystem. Note, this option
             requires the write plugin.
         dup_track: If given, the new track created will be a duplicate of `dup_track`.
-        custom_fields: Dict of custom_fields to values to assign to the track.
         **kwargs: Any other fields to assign to the Track.
 
     Returns:
@@ -190,11 +188,6 @@ def track_factory(
         **kwargs,
     )
 
-    if custom_fields:
-        for field, value in custom_fields.items():
-            track.custom_fields.add(field)
-            setattr(track, field, value)
-
     if dup_track:
         for field in dup_track.fields:
             value = getattr(dup_track, field)
@@ -217,7 +210,6 @@ def extra_factory(
     path: Optional[Path] = None,
     exists: bool = False,
     dup_extra: Optional[Extra] = None,
-    custom_fields: Optional[dict[str, Any]] = None,
     **kwargs,
 ) -> Extra:
     """Creates an extra for testing.
@@ -227,7 +219,6 @@ def extra_factory(
         path: Path to assign to the extra. Will create a random path if not given.
         exists: Whether the extra should actually exist on the filesystem.
         dup_extra: If given, the new extra created will be a duplicate of `dup_extra`.
-        custom_fields: Dict of custom_fields to values to assign to the extra.
         **kwargs: Any other fields to assign to the extra.
 
     Returns:
@@ -237,11 +228,6 @@ def extra_factory(
     path = path or album.path / f"{random.randint(1,10000)}.txt"
 
     extra = Extra(album=album, path=path, **kwargs)
-
-    if custom_fields:
-        for field, value in custom_fields.items():
-            extra.custom_fields.add(field)
-            setattr(extra, field, value)
 
     if dup_extra:
         for field in dup_extra.fields:
@@ -264,7 +250,6 @@ def album_factory(
     num_discs: int = 1,
     exists: bool = False,
     dup_album: Optional[Album] = None,
-    custom_fields: Optional[dict[str, Any]] = None,
     **kwargs,
 ) -> Album:
     """Creates an album.
@@ -276,7 +261,6 @@ def album_factory(
         exists: Whether the album should exist on the filesystem. Note, this option
             requires the write plugin.
         dup_album: If given, the new album created will be a duplicate of `dup_album`.
-        custom_fields: Dict of custom_fields to values to assign to the album.
         **kwargs: Any other fields to assign to the album.
 
     Returns:
@@ -298,10 +282,6 @@ def album_factory(
         track_total=num_tracks,
         **kwargs,
     )
-    if custom_fields:
-        for field, value in custom_fields.items():
-            album.custom_fields.add(field)
-            setattr(album, field, value)
 
     if dup_album:
         for field in dup_album.fields:

--- a/tests/library/test_album.py
+++ b/tests/library/test_album.py
@@ -19,12 +19,6 @@ class MyAlbumPlugin:
 
     @staticmethod
     @moe.hookimpl
-    def create_custom_album_fields():
-        """Create a new custom field."""
-        return {"no_default": None, "default": "value"}
-
-    @staticmethod
-    @moe.hookimpl
     def is_unique_album(album, other):
         """Albums with the same title aren't unique."""
         if album.title == other.title:
@@ -33,14 +27,6 @@ class MyAlbumPlugin:
 
 class TestHooks:
     """Test album hooks."""
-
-    def test_create_custom_fields(self, tmp_config):
-        """Plugins can define new custom fields."""
-        tmp_config(extra_plugins=[ExtraPlugin(MyAlbumPlugin, "album_plugin")])
-        album = album_factory()
-
-        assert not album.no_default
-        assert album.default == "value"
 
     def test_is_unique_album(self, tmp_config):
         """Plugins can add additional unique constraints."""
@@ -226,6 +212,15 @@ class TestMetaAlbumMerge:
 
         assert overwrite_track.title == "conflict"
 
+    def test_custom_fields(self):
+        """Merge custom fields too."""
+        album = MetaAlbum(custom=None)
+        other_album = MetaAlbum(custom="new")
+
+        album.merge(other_album)
+
+        assert album.custom["custom"] == "new"
+
 
 class TestAlbumMerge:
     """Test merging two Albums together."""
@@ -332,6 +327,15 @@ class TestAlbumMerge:
         album1.merge(album2, overwrite=True)
 
         assert overwrite_track.title == "conflict"
+
+    def test_custom_fields(self):
+        """Merge custom fields too."""
+        album = album_factory(custom="")
+        other_album = album_factory(custom="new")
+
+        album.merge(other_album)
+
+        assert album.custom["custom"] == "new"
 
 
 class TestFromDir:

--- a/tests/library/test_extra.py
+++ b/tests/library/test_extra.py
@@ -13,12 +13,6 @@ class MyExtraPlugin:
 
     @staticmethod
     @moe.hookimpl
-    def create_custom_extra_fields():
-        """Create a new custom field."""
-        return {"no_default": None, "default": "value"}
-
-    @staticmethod
-    @moe.hookimpl
     def is_unique_extra(extra, other):
         """Extras with the same title aren't unique."""
         if extra.custom == other.custom:
@@ -27,14 +21,6 @@ class MyExtraPlugin:
 
 class TestHooks:
     """Test extra hooks."""
-
-    def test_create_custom_fields(self, tmp_config):
-        """Plugins can define new custom fields."""
-        tmp_config(extra_plugins=[ExtraPlugin(MyExtraPlugin, "extra_plugin")])
-        extra = extra_factory()
-
-        assert not extra.no_default
-        assert extra.default == "value"
 
     def test_is_unique_extra(self, tmp_config):
         """Plugins can add additional unique constraints."""
@@ -77,21 +63,21 @@ class TestMerge:
 
     def test_merge_non_conflict(self):
         """Apply any non-conflicting fields."""
-        extra = extra_factory(custom_fields={"custom": "keep"})
-        other_extra = extra_factory(custom_fields={"custom": None})
+        extra = extra_factory(custom="keep")
+        other_extra = extra_factory(custom=None)
 
         extra.merge(other_extra)
 
-        assert extra.custom == "keep"
+        assert extra.custom["custom"] == "keep"
 
     def test_none_merge(self):
         """Don't merge in any null values."""
-        extra = extra_factory(custom_fields={"custom": None})
-        other_extra = extra_factory(custom_fields={"custom": "keep"})
+        extra = extra_factory(custom=None)
+        other_extra = extra_factory(custom="keep")
 
         extra.merge(other_extra)
 
-        assert extra.custom == "keep"
+        assert extra.custom["custom"] == "keep"
 
     def test_db_delete(self, tmp_session):
         """Remove the other extra from the db if it exists."""

--- a/tests/library/test_lib_item.py
+++ b/tests/library/test_lib_item.py
@@ -1,8 +1,5 @@
 """Test shared library functionality."""
 
-
-import pytest
-
 import moe
 from moe.config import ExtraPlugin, MoeSession
 from moe.library import Album, Extra, Track
@@ -14,56 +11,38 @@ class LibItemPlugin:
 
     @staticmethod
     @moe.hookimpl
-    def create_custom_album_fields():
-        """Adds relevant musicbrainz fields to a track."""
-        return {"changed": None, "new": None, "removed": None}
-
-    @staticmethod
-    @moe.hookimpl
-    def create_custom_extra_fields():
-        """Adds relevant musicbrainz fields to a track."""
-        return {"changed": None, "new": None, "removed": None}
-
-    @staticmethod
-    @moe.hookimpl
-    def create_custom_track_fields():
-        """Adds relevant musicbrainz fields to a track."""
-        return {"changed": None, "new": None, "removed": None}
-
-    @staticmethod
-    @moe.hookimpl
     def edit_changed_items(items):
         """Edit changed items."""
         for item in items:
-            item.changed = "edited"
+            item.custom["changed"] = "edited"
 
     @staticmethod
     @moe.hookimpl
     def edit_new_items(items):
         """Edit new items."""
         for item in items:
-            item.new = "edited"
+            item.custom["new"] = "edited"
 
     @staticmethod
     @moe.hookimpl
     def process_changed_items(items):
         """Process changed items."""
         for item in items:
-            item.changed = "processed"
+            item.custom["changed"] = "processed"
 
     @staticmethod
     @moe.hookimpl
     def process_new_items(items):
         """Process new items."""
         for item in items:
-            item.new = "processed"
+            item.custom["new"] = "processed"
 
     @staticmethod
     @moe.hookimpl
     def process_removed_items(items):
         """Process removed items."""
         for item in items:
-            item.removed = "processed"
+            item.custom["removed"] = "processed"
 
 
 class TestHooks:
@@ -79,9 +58,6 @@ class TestHooks:
         album = album_factory()
         extra = extra_factory()
         track = track_factory()
-        assert not album.changed
-        assert not extra.changed
-        assert not track.changed
 
         session = MoeSession()
         session.add(album)
@@ -89,14 +65,14 @@ class TestHooks:
         session.add(track)
         session.commit()
 
-        album.changed = "triggered"
-        extra.changed = "triggered"
-        track.changed = "triggered"
+        album.custom["changed"] = "triggered"
+        extra.custom["changed"] = "triggered"
+        track.custom["changed"] = "triggered"
         session.commit()
 
-        assert album.changed == "edited"
-        assert extra.changed == "edited"
-        assert track.changed == "edited"
+        assert album.custom["changed"] == "edited"
+        assert extra.custom["changed"] == "edited"
+        assert track.custom["changed"] == "edited"
 
     def test_edit_new_items(self, tmp_config):
         """Ensure plugins can implement the `edit_new_items` hook."""
@@ -108,9 +84,6 @@ class TestHooks:
         album = album_factory()
         extra = extra_factory()
         track = track_factory()
-        assert not album.new
-        assert not extra.new
-        assert not track.new
 
         session = MoeSession()
         session.add(album)
@@ -118,9 +91,9 @@ class TestHooks:
         session.add(track)
         session.commit()
 
-        assert album.new == "edited"
-        assert extra.new == "edited"
-        assert track.new == "edited"
+        assert album.custom["new"] == "edited"
+        assert extra.custom["new"] == "edited"
+        assert track.custom["new"] == "edited"
 
     def test_process_changed_items(self, tmp_config):
         """Ensure plugins can implement the `edit_edited_items` hook."""
@@ -132,9 +105,6 @@ class TestHooks:
         album = album_factory()
         extra = extra_factory()
         track = track_factory()
-        assert not album.changed
-        assert not extra.changed
-        assert not track.changed
 
         session = MoeSession()
         session.add(album)
@@ -142,19 +112,19 @@ class TestHooks:
         session.add(track)
         session.commit()
 
-        album.changed = "triggered"
-        extra.changed = "triggered"
-        track.changed = "triggered"
+        album.custom["changed"] = "triggered"
+        extra.custom["changed"] = "triggered"
+        track.custom["changed"] = "triggered"
         session.flush()
-        assert album.changed == "processed"
-        assert extra.changed == "processed"
-        assert track.changed == "processed"
+        assert album.custom["changed"] == "processed"
+        assert extra.custom["changed"] == "processed"
+        assert track.custom["changed"] == "processed"
 
         # changes won't persist
         session.commit()
-        assert album.changed != "processed"
-        assert extra.changed != "processed"
-        assert track.changed != "processed"
+        assert album.custom["changed"] != "processed"
+        assert extra.custom["changed"] != "processed"
+        assert track.custom["changed"] != "processed"
 
     def test_process_new_items(self, tmp_config):
         """Ensure plugins can implement the `edit_new_items` hook."""
@@ -166,9 +136,6 @@ class TestHooks:
         album = album_factory()
         extra = extra_factory()
         track = track_factory()
-        assert not album.new
-        assert not extra.new
-        assert not track.new
 
         session = MoeSession()
         session.add(album)
@@ -176,15 +143,15 @@ class TestHooks:
         session.add(track)
 
         session.flush()
-        assert album.new == "processed"
-        assert extra.new == "processed"
-        assert track.new == "processed"
+        assert album.custom["new"] == "processed"
+        assert extra.custom["new"] == "processed"
+        assert track.custom["new"] == "processed"
 
         # changes won't persist
         session.commit()
-        assert album.new != "processed"
-        assert extra.new != "processed"
-        assert track.new != "processed"
+        assert album.custom["new"] != "processed"
+        assert extra.custom["new"] != "processed"
+        assert track.custom["new"] != "processed"
 
     def test_process_removed_items(self, tmp_config):
         """Ensure plugins can implement the `edit_removed_items` hook."""
@@ -196,9 +163,6 @@ class TestHooks:
         album = album_factory()
         extra = extra_factory(album=album)
         track = track_factory(album=album)
-        assert not album.removed
-        assert not extra.removed
-        assert not track.removed
 
         session = MoeSession()
         session.add(album)
@@ -211,9 +175,9 @@ class TestHooks:
         session.delete(track)
         session.flush()
 
-        assert album.removed == "processed"
-        assert extra.removed == "processed"
-        assert track.removed == "processed"
+        assert album.custom["removed"] == "processed"
+        assert extra.custom["removed"] == "processed"
+        assert track.custom["removed"] == "processed"
         assert not session.query(Album).all()
         assert not session.query(Extra).all()
         assert not session.query(Track).all()
@@ -224,59 +188,33 @@ class TestCustomFields:
 
     def test_db_persistence(self, tmp_session):
         """Ensure custom fields persist in the database."""
-        track = track_factory(
-            custom_fields={"db": "persists", "my_list": [1, "change me"]}
-        )
+        track = track_factory(db="persists", my_list=[1, "change me"])
 
-        track.db = "persisted"
-        track.my_list[1] = "changed"
+        track.custom["db"] = "persisted"
+        track.custom["my_list"][1] = "changed"
         tmp_session.add(track)
         tmp_session.flush()
 
         db_track = tmp_session.query(Track).one()
-        assert db_track.db == "persisted"
-        assert db_track.my_list == [1, "changed"]
+        assert db_track.custom["db"] == "persisted"
+        assert db_track.custom["my_list"] == [1, "changed"]
 
     def test_db_changes(self, tmp_config):
         """Ensure custom fields changes also persist in the database."""
         tmp_config(settings="default_plugins = []", tmp_db=True)
         track = track_factory(
-            custom_fields={
-                "db": "persists",
-                "my_list": ["wow", "change me"],
-                "growing_list": ["one"],
-            }
+            db="persists", my_list=["wow", "change me"], growing_list=["one"]
         )
 
         session = MoeSession()
         session.add(track)
         session.commit()
-        track.db = "persisted"
-        track.my_list[1] = "changed"
-        track.growing_list.append("two")
+        track.custom["db"] = "persisted"
+        track.custom["my_list"][1] = "changed"
+        track.custom["growing_list"].append("two")
         assert track in session.dirty
 
         db_track = session.query(Track).one()
-        assert db_track.db == "persisted"
-        assert db_track.my_list == ["wow", "changed"]
-        assert db_track.growing_list == ["one", "two"]
-
-    def test_set_non_key(self):
-        """Don't set just any attribute as a custom field if the key doesn't exist."""
-        track = track_factory(custom_key=1)
-
-        with pytest.raises(KeyError):
-            assert track._custom_fields["custom_key"] == 1
-
-    def test_get_custom_field(self):
-        """We can get a custom field like a normal attribute."""
-        track = track_factory(custom_fields={"custom": "field"})
-
-        assert track.custom == "field"
-
-    def test_set_custom_field(self):
-        """We can set a custom field like a normal attribute."""
-        track = track_factory(custom_fields={"custom_key": None})
-        track.custom_key = "test"
-
-        assert track._custom_fields["custom_key"] == "test"
+        assert db_track.custom["db"] == "persisted"
+        assert db_track.custom["my_list"] == ["wow", "changed"]
+        assert db_track.custom["growing_list"] == ["one", "two"]

--- a/tests/plugins/add/test_add_core.py
+++ b/tests/plugins/add/test_add_core.py
@@ -85,8 +85,8 @@ class TestAddItem:
     @pytest.mark.usefixtures("_tmp_add_config")
     def test_duplicate_list_field_tracks(self, tmp_session):
         """Duplicate list fields don't error when adding multiple tracks."""
-        track1 = track_factory(genre="pop")
-        track2 = track_factory(genre="pop")
+        track1 = track_factory(genres={"pop"})
+        track2 = track_factory(genres={"pop"})
 
         add.add_item(track1)
         add.add_item(track2)

--- a/tests/plugins/duplicate/test_dup_cli.py
+++ b/tests/plugins/duplicate/test_dup_cli.py
@@ -109,8 +109,7 @@ class TestUI:
             num_discs=2,
         )
         old_album.tracks[0].title = "really really long old title"
-        old_album.tracks[0].custom_fields.add("new field")
-        old_album.tracks[0].new_field = "whoa a new field"
+        old_album.tracks[0].custom["custom_field"] = "custom field!"
 
         assert old_album is not new_album
 

--- a/tests/plugins/edit/test_edit_core.py
+++ b/tests/plugins/edit/test_edit_core.py
@@ -75,10 +75,10 @@ class TestEditItem:
 
     def test_custom_field(self):
         """We can edit custom fields."""
-        track = track_factory(custom_fields={"my_title": "test"})
+        track = track_factory(my_title="test")
         edit.edit_item(track, "my_title", "new")
 
-        assert track.my_title == "new"
+        assert track.custom["my_title"] == "new"
 
 
 class TestPluginRegistration:

--- a/tests/plugins/musicbrainz/test_mb_cli.py
+++ b/tests/plugins/musicbrainz/test_mb_cli.py
@@ -39,7 +39,7 @@ class TestCollectionCommand:
         """Tracks associated album's are used."""
         cli_args = ["mbcol", "*"]
         track = track_factory()
-        track.album.mb_album_id = "123"
+        track.album.custom["mb_album_id"] = "123"
         mock_query.return_value = [track]
 
         with patch(
@@ -54,7 +54,7 @@ class TestCollectionCommand:
         """Extras associated album's are used."""
         cli_args = ["mbcol", "-e", "*"]
         extra = extra_factory()
-        extra.album.mb_album_id = "123"
+        extra.album.custom["mb_album_id"] = "123"
         mock_query.return_value = [extra]
 
         with patch(
@@ -68,7 +68,7 @@ class TestCollectionCommand:
     def test_album(self, mock_query):
         """Albums associated releases are used."""
         cli_args = ["mbcol", "-a", "*"]
-        album = album_factory(custom_fields={"mb_album_id": "123"})
+        album = album_factory(mb_album_id="123")
         mock_query.return_value = [album]
 
         with patch(
@@ -83,7 +83,7 @@ class TestCollectionCommand:
         """Releases are removed from a collection if `--remove` option used."""
         cli_args = ["mbcol", "--remove", "*"]
         track = track_factory()
-        track.album.mb_album_id = "123"
+        track.album.custom["mb_album_id"] = "123"
         mock_query.return_value = [track]
 
         with patch(
@@ -98,7 +98,7 @@ class TestCollectionCommand:
         """Releases are added to a collection if `--add` option used."""
         cli_args = ["mbcol", "--add", "*"]
         track = track_factory()
-        track.album.mb_album_id = "123"
+        track.album.custom["mb_album_id"] = "123"
         mock_query.return_value = [track]
 
         with patch(

--- a/tests/plugins/musicbrainz/test_mb_core.py
+++ b/tests/plugins/musicbrainz/test_mb_core.py
@@ -153,7 +153,7 @@ class TestCollectionsAutoRemove:
         ) as mock_rm_releases_call:
             mb_config.pm.hook.process_removed_items(items=[album])
 
-        mock_rm_releases_call.assert_called_once_with({album.mb_album_id})
+        mock_rm_releases_call.assert_called_once_with({album.custom["mb_album_id"]})
 
     def test_all_items(self, mb_config):
         """Remove all items from the collection if `auto_remove` is true."""
@@ -167,7 +167,7 @@ class TestCollectionsAutoRemove:
             mb_config.pm.hook.process_removed_items(items=[album1, album2])
 
         mock_rm_releases_call.assert_called_once_with(
-            {album1.mb_album_id, album2.mb_album_id}
+            {album1.custom["mb_album_id"], album2.custom["mb_album_id"]}
         )
 
     def test_auto_remove_false(self, mb_config):
@@ -223,7 +223,7 @@ class TestCollectionsAutoAdd:
         ) as mock_add_releases_call:
             mb_config.pm.hook.process_new_items(items=[album])
 
-        mock_add_releases_call.assert_called_once_with({album.mb_album_id})
+        mock_add_releases_call.assert_called_once_with({album.custom["mb_album_id"]})
 
     def test_auto_add_false(self, mb_config):
         """Don't add any items if `auto_add` set to false."""
@@ -278,12 +278,13 @@ class TestSyncMetadata:
         ) as mock_id:
             config.CONFIG.pm.hook.sync_metadata(item=old_album)
 
-        mock_id.assert_called_once_with(old_album.mb_album_id)
+        mock_id.assert_called_once_with(old_album.custom["mb_album_id"])
         assert old_album.title == "synced"
 
     def test_sync_track(self, mb_config):
         """Tracks are synced with musicbrainz when called."""
         old_track = track_factory(title="unsynced", mb_track_id="1")
+        old_track.album.custom["mb_album_id"] = "2"
         new_track = track_factory(title="synced")
 
         with patch.object(
@@ -292,7 +293,7 @@ class TestSyncMetadata:
             config.CONFIG.pm.hook.sync_metadata(item=old_track)
 
         mock_id.assert_called_once_with(
-            old_track.mb_track_id, old_track.album.mb_album_id
+            old_track.custom["mb_track_id"], old_track.album.custom["mb_album_id"]
         )
         assert old_track.title == "synced"
 
@@ -453,8 +454,8 @@ class TestCustomFields:
 
         new_track = Track.from_file(track.path)
 
-        assert new_track.album.mb_album_id == "album id"
-        assert new_track.mb_track_id == "track id"
+        assert new_track.album.custom["mb_album_id"] == "album id"
+        assert new_track.custom["mb_track_id"] == "track id"
 
 
 class TestAddReleasesToCollection:

--- a/tests/plugins/test_list.py
+++ b/tests/plugins/test_list.py
@@ -109,6 +109,16 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
+    def test_custom_info(self, capsys, mock_query):
+        """Output custom fields as well."""
+        cli_args = ["list", "--info", "*"]
+        mock_query.return_value = [track_factory(custom="show me")]
+
+        moe.cli.main(cli_args)
+
+        output = capsys.readouterr().out.split("\n")
+        assert "custom: show me" in output
+
 
 class TestPluginRegistration:
     """Test the `plugin_registration` hook implementation."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -238,35 +238,35 @@ class TestQueries:
 
     def test_custom_fields(self, tmp_session):
         """We can query a custom field."""
-        album = album_factory(custom_fields={"custom": "album"})
-        extra_factory(album=album, custom_fields={"custom": "extra"})
-        track_factory(album=album, custom_fields={"custom": "track"})
+        album = album_factory(blah="album")
+        extra_factory(album=album, blah="extra")
+        track_factory(album=album, blah="track")
 
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query("a:custom:album t:custom:track e:custom:extra", "album")
+        assert query("a:blah:album t:blah:track e:blah:extra", "album")
 
     def test_custom_field_regex(self, tmp_session):
         """We can regex query a custom field."""
-        album = album_factory(custom_fields={"custom": "album"})
-        extra_factory(album=album, custom_fields={"custom": 3})
-        track_factory(album=album, custom_fields={"custom": "track"})
+        album = album_factory(blah="album")
+        extra_factory(album=album, blah=3)
+        track_factory(album=album, blah="track")
 
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query("a:custom::albu. t:custom::trac. e:custom::3", "album")
+        assert query("a:blah::albu. t:blah::trac. e:blah::3", "album")
 
     def test_custom_list_field(self, tmp_session):
         """We can query custom list fields."""
-        album = album_factory(custom_fields={"custom": ["album", 1]})
-        extra_factory(album=album, custom_fields={"custom": ["extra", 2]})
-        track_factory(album=album, custom_fields={"custom": ["track", 3]})
+        album = album_factory(blah=["album", 1])
+        extra_factory(album=album, blah=["extra", 2])
+        track_factory(album=album, blah=["track", 3])
 
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query("a:custom:album t:custom:track e:custom:extra", "album")
-        assert query("a:custom:1 e:custom:2 t:custom:3", "album")
-        assert query("t:custom:3 t:custom:track", "album")
+        assert query("a:blah:album t:blah:track e:blah:extra", "album")
+        assert query("a:blah:1 e:blah:2 t:blah:3", "album")
+        assert query("t:blah:3 t:blah:track", "album")


### PR DESCRIPTION
Custom fields must now be accessed via `item.custom["my_custom_field"]` i.e. normal dictionary access.

I changed this from normal attribute access as overriding `__getattr__` and `__setattr__` (required for transparent attribute access) had some finicky conflicts with sqlalchemy. Also, it preventing type hinting the custom attribute dictionary as well as integration with data serializers such as pydantic.

Overall, the more I used them, the more issues I found, and the more it felt like a hack. I believe the new explicit dictionary access for custom attributes will prove to be more bulletproof. It also explicitly delineates normal and custom attributes which can be useful in some cases.


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--243.org.readthedocs.build/en/243/

<!-- readthedocs-preview mrmoe end -->