### PR TITLE
refactor!: replace lib_path arg for fmt_item_path with optional parent

### DIFF
--- a/tests/move/test_move_core.py
+++ b/tests/move/test_move_core.py
@@ -153,8 +153,8 @@ class TestFmtItemPath:
         assert str(moe_move.fmt_item_path(album)).isascii()
 
     @pytest.mark.usefixtures("_tmp_move_config")
-    def test_given_lib_path(self, tmp_path):
-        """If provided, paths should be relative to ``lib_path``."""
+    def test_given_parent(self, tmp_path):
+        """If provided, paths should be relative to ``parent``."""
         track = track_factory()
         track_path = moe_move.fmt_item_path(track, tmp_path)
 


### PR DESCRIPTION
This is more flexible as it allows specifying the direct parent for albums, extras and tracks instead of just albums.


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--250.org.readthedocs.build/en/250/

<!-- readthedocs-preview mrmoe end -->