### PR TITLE
refactor!: changed CandidateAlbum fields

### DIFF
--- a/moe/moe_import/import_cli.py
+++ b/moe/moe_import/import_cli.py
@@ -150,10 +150,10 @@ def candidate_prompt(new_album: Album, candidates: list[CandidateAlbum]):
 def _fmt_candidate_info(candidate: CandidateAlbum) -> str:
     """Formats a candidates info for the candidate prompt."""
     sub_header_values = []
-    for str_field in ["media", "country", "label", "catalog_num"]:
-        if value := getattr(candidate.album, str_field):
+    for field in ["media", "country", "label", "catalog_num"]:
+        if value := getattr(candidate.album, field):
             sub_header_values.append(value)
-    sub_header_values.extend(candidate.sub_header_info)
+    sub_header_values.extend(candidate.disambigs)
     sub_header = " | ".join(sub_header_values)
 
     return (
@@ -163,7 +163,7 @@ def _fmt_candidate_info(candidate: CandidateAlbum) -> str:
         + sub_header
         + "\n"
         + " " * (9 + len(candidate.match_value_pct))
-        + candidate.source_str
+        + f"{candidate.plugin_source.capitalize()}: {candidate.source_id}"
         + "\n"
     )
 
@@ -273,7 +273,7 @@ def _fmt_album(new_album: Album, candidate: CandidateAlbum) -> Text:
     return (
         header_text.append_text(sub_header_text)
         .append("\n")
-        .append(candidate.source_str)
+        .append(f"{candidate.plugin_source.capitalize()}: {candidate.source_id}")
         .append("\n")
     )
 

--- a/moe/moe_import/import_core.py
+++ b/moe/moe_import/import_core.py
@@ -22,21 +22,22 @@ class CandidateAlbum:
 
     Attributes:
         album (Album): The candidate album.
+        disambigs (list[str]): Any additional source-specific values that may be used to
+            disambiguate or identify the candidate from others.
         match_value (float): 0 to 1 scale of how well the candidate album matches with
             the album being imported.
-        source_str (str): A string identifying the release and it's source
-            e.g. 'Musicbrainz: 1234'. This will be displayed as the last line in the
-            candidate prompt.
-        sub_header_info (list[str]): List of any additional info to include in the
-            candidate sub-header. The following fields are already included:
-            ['media', 'country', 'label']
         match_value_pct (str): ``match_value`` as a percentage.
+        plugin_source (str): String identifying the plugin this candidate came from e.g
+            "musicbrainz".
+        source_id (str): A unique string identifying the release within the source e.g.
+            musicbrainz' release id.
     """
 
     album: MetaAlbum
     match_value: float
-    source_str: str
-    sub_header_info: list[str] = field(default_factory=list)
+    plugin_source: str
+    source_id: str
+    disambigs: list[str] = field(default_factory=list)
 
     @property
     def match_value_pct(self) -> str:

--- a/tests/add/test_add_cli.py
+++ b/tests/add/test_add_cli.py
@@ -49,7 +49,11 @@ class AddCLIPlugin:
     @moe.hookimpl
     def get_candidates(album: Album) -> list[CandidateAlbum]:
         """Return a fake candidate for testing."""
-        return [CandidateAlbum(album=album, match_value=1, source_str="add plugin")]
+        return [
+            CandidateAlbum(
+                album=album, match_value=1, plugin_source="add plugin", source_id="1"
+            )
+        ]
 
 
 @pytest.mark.usefixtures("_tmp_add_config")

--- a/tests/import/test_import_cli.py
+++ b/tests/import/test_import_cli.py
@@ -29,7 +29,10 @@ class TestPrompt:
         tmp_config("default_plugins = ['cli', 'import']", tmp_db=True)
         album = album_factory(num_discs=2)
         candidate = CandidateAlbum(
-            album=album_factory(num_discs=2), match_value=1, source_str="Tests"
+            album=album_factory(num_discs=2),
+            match_value=1,
+            plugin_source="Tests",
+            source_id="1",
         )
 
         mock_choice = PromptChoice("mock", "m", moe_import.import_cli._apply_changes)
@@ -70,7 +73,10 @@ class TestHookSpecs:
         """Plugins can add prompt choices to the import prompt."""
         album = album_factory()
         candidate = CandidateAlbum(
-            album=album_factory(), match_value=1, source_str="tests"
+            album=album_factory(),
+            match_value=1,
+            plugin_source="Tests",
+            source_id="1",
         )
         album.title = "not ImportPlugin"
         tmp_config(
@@ -152,7 +158,10 @@ class TestAddImportPromptChoice:
         """
         album = album_factory()
         candidate = CandidateAlbum(
-            album=album_factory(), match_value=1, source_str="test"
+            album=album_factory(),
+            match_value=1,
+            plugin_source="tests",
+            source_id="1",
         )
         missing_track = track_factory(
             album=candidate.album, track_num=len(album.tracks) + 1
@@ -185,7 +194,10 @@ class TestAddImportPromptChoice:
         """
         album = album_factory(num_tracks=0)
         candidate = CandidateAlbum(
-            album=album_factory(num_tracks=0), match_value=1, source_str="tests"
+            album=album_factory(num_tracks=0),
+            match_value=1,
+            plugin_source="tests",
+            source_id="1",
         )
         track_factory(album=album, track_num=1, title="old track 1")
         track_factory(album=candidate.album, track_num=1, title="new track 1")
@@ -224,7 +236,10 @@ class TestAddImportPromptChoice:
         """`apply` prompt choice should keep any extras."""
         album = album_factory()
         candidate = CandidateAlbum(
-            album=album_factory(), match_value=1, source_str="tests"
+            album=album_factory(),
+            match_value=1,
+            plugin_source="tests",
+            source_id="1",
         )
         new_extra = extra_factory(album=album)
 
@@ -242,7 +257,10 @@ class TestAddImportPromptChoice:
         """Fields get applied onto the old album."""
         album = album_factory()
         candidate = CandidateAlbum(
-            album=album_factory(title="new title"), match_value=1, source_str="tests"
+            album=album_factory(title="new title"),
+            match_value=1,
+            plugin_source="tests",
+            source_id="1",
         )
         assert album.title != candidate.album.title
 
@@ -272,7 +290,10 @@ class TestAddImportPromptChoice:
         """The `abort` prompt choice should raise an AbortImport error."""
         album = album_factory()
         candidate = CandidateAlbum(
-            album=album_factory(), match_value=1, source_str="tests"
+            album=album_factory(),
+            match_value=1,
+            plugin_source="tests",
+            source_id="1",
         )
 
         mock_choice = PromptChoice("mock", "m", moe_import.import_cli._abort_changes)
@@ -328,7 +349,8 @@ class TestImportCLIOutput:
                 label="me",
             ),
             match_value=1,
-            source_str="tests",
+            plugin_source="tests",
+            source_id="1",
         )
         album.tracks[0].title = "really really long old title"
 

--- a/tests/import/test_import_core.py
+++ b/tests/import/test_import_core.py
@@ -20,7 +20,9 @@ class ImportPlugin:
         """Changes the album title."""
         album.title = "candidate title"
 
-        return [CandidateAlbum(album=album, match_value=1, source_str="hook")]
+        return [
+            CandidateAlbum(album, match_value=1, plugin_source="hook", source_id="1")
+        ]
 
     @staticmethod
     @moe.hookimpl
@@ -59,7 +61,9 @@ class TestHookSpecs:
         config.CONFIG.pm.hook.process_candidates(
             new_album=album,
             candidates=[
-                CandidateAlbum(album=new_album, match_value=1, source_str="tests")
+                CandidateAlbum(
+                    album=new_album, match_value=1, plugin_source="tests", source_id="1"
+                )
             ],
         )
 


### PR DESCRIPTION
* `source_str` is now split into two fields: `plugin_source` and `source_id`. This is so in the future we can check against the `plugin_source` and apply different handling criteria per plugin e.g. import weight values.
* `sub_header_info` renamed to `disambigs`. The "sub-header" is specific to the cli, so it was renamed to be more generalized.


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--251.org.readthedocs.build/en/251/

<!-- readthedocs-preview mrmoe end -->