### PR TITLE
refactor!: db sessions are now explicitly passed as arguments

### DIFF
--- a/moe/add/add_core.py
+++ b/moe/add/add_core.py
@@ -6,6 +6,7 @@ This module provides the main entry point into the add process via ``add_item()`
 import logging
 
 import pluggy
+from sqlalchemy.orm.session import Session
 
 import moe
 from moe import config
@@ -61,17 +62,17 @@ class AddAbortError(Exception):
     """Add process has been aborted by the user."""
 
 
-def add_item(item: LibItem):
+def add_item(session: Session, item: LibItem):
     """Adds a LibItem to the library.
 
     Args:
+        session: Library db session.
         item: Item to be added.
 
     Raises:
         AddError: Unable to add the item to the library.
     """
     log.debug(f"Adding item to the library. [{item=!r}]")
-    session = config.MoeSession()
 
     config.CONFIG.pm.hook.pre_add(item=item)
     session.add(item)

--- a/moe/cli.py
+++ b/moe/cli.py
@@ -16,7 +16,7 @@ from rich.console import Console
 
 import moe
 from moe import config
-from moe.config import Config, ConfigValidationError, MoeSession
+from moe.config import Config, ConfigValidationError, moe_sessionmaker
 
 __all__ = ["console"]
 
@@ -50,7 +50,7 @@ class Hooks:
             The function will be called like::
 
                 func(
-                    config: moe.Config,  # user config
+                    session: sqlalchemy.orm.session.Session, # library db session
                     args: argparse.Namespace,  # parsed commandline arguments
                 )
 
@@ -108,12 +108,11 @@ def _parse_args(args: list[str]):
     _set_log_lvl(parsed_args)
 
     # call the sub-command's handler within a single session
-    cli_session = MoeSession()
-    with cli_session.begin():
+    with moe_sessionmaker.begin() as session:
         try:
-            parsed_args.func(args=parsed_args)
+            parsed_args.func(session=session, args=parsed_args)
         except SystemExit:
-            cli_session.commit()
+            session.commit()
             raise
 
 

--- a/moe/edit/edit_cli.py
+++ b/moe/edit/edit_cli.py
@@ -3,6 +3,8 @@
 import argparse
 import logging
 
+from sqlalchemy.orm.session import Session
+
 import moe
 import moe.cli
 from moe import edit
@@ -37,17 +39,18 @@ def add_command(cmd_parsers: argparse._SubParsersAction):
     edit_parser.set_defaults(func=_parse_args)
 
 
-def _parse_args(args: argparse.Namespace):  # noqa: C901
+def _parse_args(session: Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Args:
+        session: Library db session.
         args: Commandline arguments to parse.
 
     Raises:
         SystemExit: Invalid query, no items found to edit, or invalid field or
             field_value term format.
     """
-    items = cli_query(args.query, args.query_type)
+    items = cli_query(session, args.query, args.query_type)
 
     error_count = 0
     for term in args.fv_terms:

--- a/moe/list.py
+++ b/moe/list.py
@@ -9,6 +9,8 @@ import logging
 from collections import OrderedDict
 from typing import Any
 
+from sqlalchemy.orm.session import Session
+
 import moe
 import moe.cli
 from moe import config
@@ -53,16 +55,17 @@ def add_command(cmd_parsers: argparse._SubParsersAction):
     ls_parser.set_defaults(func=_parse_args)
 
 
-def _parse_args(args: argparse.Namespace):
+def _parse_args(session: Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Args:
+        session: Library db session.
         args: Commandline arguments to parse.
 
     Raises:
         SystemExit: Invalid query or no items found.
     """
-    items = cli_query(args.query, query_type=args.query_type)
+    items = cli_query(session, args.query, query_type=args.query_type)
     items.sort()
 
     if args.info:

--- a/moe/move/move_cli.py
+++ b/moe/move/move_cli.py
@@ -5,6 +5,7 @@ import logging
 from typing import cast
 
 import sqlalchemy.orm
+from sqlalchemy.orm.session import Session
 
 import moe
 from moe import move as moe_move
@@ -32,18 +33,19 @@ def add_command(cmd_parsers: argparse._SubParsersAction):
     move_parser.set_defaults(func=_parse_args)
 
 
-def _parse_args(args: argparse.Namespace):
+def _parse_args(session: Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Items will be moved according to the given user configuration.
 
     Args:
+        session: Library db session.
         args: Commandline arguments to parse.
 
     Raises:
         SystemExit: Invalid query or no items found to move.
     """
-    albums = cast(list[Album], cli_query("*", query_type="album"))
+    albums = cast(list[Album], cli_query(session, "*", query_type="album"))
 
     if args.dry_run:
         dry_run_str = _dry_run(albums)

--- a/moe/query.py
+++ b/moe/query.py
@@ -9,8 +9,8 @@ from typing import Type
 import sqlalchemy as sa
 import sqlalchemy.orm
 import sqlalchemy.sql.elements
+from sqlalchemy.orm.session import Session
 
-from moe.config import MoeSession
 from moe.library import Album, Extra, LibItem, Track
 from moe.library.lib_item import SetType
 
@@ -66,10 +66,11 @@ SEPARATOR = "separator"
 VALUE = "value"
 
 
-def query(query_str: str, query_type: str) -> list[LibItem]:
+def query(session: Session, query_str: str, query_type: str) -> list[LibItem]:
     """Queries the database for items matching the given query string.
 
     Args:
+        session: Library db session.
         query_str: Query string to parse. See HELP_STR for more info.
         query_type: Type of library item to return: either 'album', 'extra', or 'track'.
 
@@ -83,7 +84,6 @@ def query(query_str: str, query_type: str) -> list[LibItem]:
         `The query docs <https://mrmoe.readthedocs.io/en/latest/query.html>`_
     """
     log.debug(f"Querying library for items. [{query_str=!r}, {query_type=!r}]")
-    session = MoeSession()
 
     terms = shlex.split(query_str)
     if not terms:

--- a/moe/read/read_cli.py
+++ b/moe/read/read_cli.py
@@ -3,6 +3,8 @@
 import argparse
 import logging
 
+from sqlalchemy.orm.session import Session
+
 import moe
 import moe.cli
 from moe import read, remove
@@ -31,18 +33,19 @@ def add_command(cmd_parsers: argparse._SubParsersAction):
     read_parser.set_defaults(func=_parse_args)
 
 
-def _parse_args(args: argparse.Namespace):
+def _parse_args(session: Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Tracks can be added as files or albums as directories.
 
     Args:
+        session: Library db session.
         args: Commandline arguments to parse.
 
     Raises:
         SystemExit: Path given does not exist.
     """
-    items = cli_query(args.query, args.query_type)
+    items = cli_query(session, args.query, args.query_type)
 
     error_count = 0
     for item in items:
@@ -50,7 +53,7 @@ def _parse_args(args: argparse.Namespace):
             read.read_item(item)
         except FileNotFoundError:
             if args.remove:
-                remove.remove_item(item)
+                remove.remove_item(session, item)
             else:
                 log.error(f"Could not find item's path. [{item=!r}]")
                 error_count += 1

--- a/moe/remove/rm_cli.py
+++ b/moe/remove/rm_cli.py
@@ -7,6 +7,8 @@ Note:
 import argparse
 import logging
 
+from sqlalchemy.orm.session import Session
+
 import moe
 import moe.cli
 from moe import remove as moe_rm
@@ -30,16 +32,17 @@ def add_command(cmd_parsers: argparse._SubParsersAction):
     rm_parser.set_defaults(func=_parse_args)
 
 
-def _parse_args(args: argparse.Namespace):
+def _parse_args(session: Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Args:
+        session: Library db session.
         args: Commandline arguments to parse.
 
     Raises:
         SystemExit: Invalid query given, or no items to remove.
     """
-    items = cli_query(args.query, query_type=args.query_type)
+    items = cli_query(session, args.query, query_type=args.query_type)
 
     for item in items:
-        moe_rm.remove_item(item)
+        moe_rm.remove_item(session, item)

--- a/moe/remove/rm_core.py
+++ b/moe/remove/rm_core.py
@@ -6,7 +6,6 @@ import sqlalchemy
 import sqlalchemy.exc
 from sqlalchemy.orm.session import Session
 
-from moe.config import MoeSession
 from moe.library import Extra, LibItem, Track
 
 __all__ = ["remove_item"]
@@ -14,10 +13,9 @@ __all__ = ["remove_item"]
 log = logging.getLogger("moe.remove")
 
 
-def remove_item(item: LibItem):
+def remove_item(session: Session, item: LibItem):
     """Removes an item from the library."""
     log.debug(f"Removing item from the library. [{item=!r}]")
-    session = MoeSession()
 
     insp = sqlalchemy.inspect(item)
     if insp.persistent:

--- a/moe/util/cli/query.py
+++ b/moe/util/cli/query.py
@@ -3,6 +3,8 @@
 import argparse
 import logging
 
+from sqlalchemy.orm.session import Session
+
 from moe.library import LibItem
 from moe.query import QueryError, query
 
@@ -58,10 +60,11 @@ query_type_group.add_argument(
 query_parser.set_defaults(query_type="track")
 
 
-def cli_query(query_str: str, query_type: str) -> list[LibItem]:
+def cli_query(session: Session, query_str: str, query_type: str) -> list[LibItem]:
     """Wrapper around the core query call, with some added cli error handling.
 
     Args:
+        session: Library db session.
         query_str: Query string to parse. See HELP_STR for more info.
         query_type: Type of library item to return: either 'album', 'extra', or 'track'.
 
@@ -72,7 +75,7 @@ def cli_query(query_str: str, query_type: str) -> list[LibItem]:
         SystemExit: QueryError or no items returned from the query.
     """
     try:
-        items = query(query_str, query_type)
+        items = query(session, query_str, query_type)
     except QueryError as err:
         log.error(err)
         raise SystemExit(1) from err

--- a/tests/add/test_add_cli.py
+++ b/tests/add/test_add_cli.py
@@ -2,7 +2,7 @@
 
 from types import FunctionType
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -68,7 +68,7 @@ class TestAddImportPromptChoice:
 
         assert any(choice.shortcut_key == "s" for choice in prompt_choices)
 
-    def test_skip_item(self, tmp_config):
+    def test_skip_item(self, tmp_config, tmp_session):
         """We can skip adding items to the library."""
         tmp_config(
             'default_plugins = ["cli", "add", "import", "write"]',
@@ -85,7 +85,7 @@ class TestAddImportPromptChoice:
         ):
             moe.cli.main(cli_args)
 
-        assert not config.MoeSession().query(Track).all()
+        assert not tmp_session.query(Track).all()
 
 
 @pytest.mark.usefixtures("_tmp_add_config")
@@ -99,7 +99,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_add.assert_called_once_with(track)
+        mock_add.assert_called_once_with(ANY, track)
 
     def test_non_track_file(self, mock_add):
         """Raise SystemExit if bad track file given."""
@@ -129,8 +129,8 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_add.assert_any_call(track)
-        mock_add.assert_any_call(album)
+        mock_add.assert_any_call(ANY, track)
+        mock_add.assert_any_call(ANY, album)
         assert mock_add.call_count == 2
 
     def test_single_error(self, tmp_path, mock_add):
@@ -145,7 +145,7 @@ class TestCommand:
             moe.cli.main(cli_args)
 
         assert error.value.code != 0
-        mock_add.assert_called_once_with(track)
+        mock_add.assert_called_once_with(ANY, track)
 
     def test_extra_file(self, mock_add, mock_query):
         """Extra files are added as tracks."""
@@ -155,7 +155,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_add.assert_called_once_with(extra)
+        mock_add.assert_called_once_with(ANY, extra)
 
     def test_extra_no_album(self, mock_add):
         """Raise SystemExit if trying to add an extra but no query was given."""

--- a/tests/add/test_add_core.py
+++ b/tests/add/test_add_core.py
@@ -34,7 +34,7 @@ class TestAddItem:
     def test_track(self, tmp_session):
         """We can add tracks to the library."""
         track = track_factory()
-        moe.add.add_item(track)
+        moe.add.add_item(tmp_session, track)
 
         assert tmp_session.query(Track).one() == track
 
@@ -42,7 +42,7 @@ class TestAddItem:
     def test_album(self, tmp_session):
         """We can add albums to the library."""
         album = album_factory()
-        moe.add.add_item(album)
+        moe.add.add_item(tmp_session, album)
 
         assert tmp_session.query(Album).one() == album
 
@@ -50,7 +50,7 @@ class TestAddItem:
     def test_extra(self, tmp_session):
         """We can add extras to the library."""
         extra = extra_factory()
-        moe.add.add_item(extra)
+        moe.add.add_item(tmp_session, extra)
 
         assert tmp_session.query(Extra).one() == extra
 
@@ -62,7 +62,7 @@ class TestAddItem:
             tmp_db=True,
         )
 
-        moe.add.add_item(track_factory())
+        moe.add.add_item(tmp_session, track_factory())
 
         db_track = tmp_session.query(Track).one()
         assert db_track.title == "pre_add"
@@ -76,7 +76,7 @@ class TestAddItem:
         track1.genre = "pop"
         track2.genre = "pop"
 
-        moe.add.add_item(album)
+        moe.add.add_item(tmp_session, album)
 
         db_tracks = tmp_session.query(Track).all()
         for track in db_tracks:
@@ -88,8 +88,8 @@ class TestAddItem:
         track1 = track_factory(genres={"pop"})
         track2 = track_factory(genres={"pop"})
 
-        moe.add.add_item(track1)
-        moe.add.add_item(track2)
+        moe.add.add_item(tmp_session, track1)
+        moe.add.add_item(tmp_session, track2)
 
         db_tracks = tmp_session.query(Track).all()
         for track in db_tracks:

--- a/tests/duplicate/test_dup_cli.py
+++ b/tests/duplicate/test_dup_cli.py
@@ -1,7 +1,7 @@
 """Test the duplicate plugin cli."""
 
 import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,13 +27,18 @@ class TestPrompt:
         track_a = track_factory()
         track_b = track_factory()
 
+        mock_session = MagicMock()
         with patch(
             "moe.duplicate.dup_cli.choice_prompt",
             autospec=True,
         ) as mock_prompt_choice:
-            config.CONFIG.pm.hook.resolve_dup_items(item_a=track_a, item_b=track_b)
+            config.CONFIG.pm.hook.resolve_dup_items(
+                session=mock_session, item_a=track_a, item_b=track_b
+            )
 
-        mock_prompt_choice.return_value.func.assert_called_once_with(track_a, track_b)
+        mock_prompt_choice.return_value.func.assert_called_once_with(
+            mock_session, track_a, track_b
+        )
 
     def test_keep_a(self, tmp_session):
         """When keeping item a."""
@@ -42,7 +47,7 @@ class TestPrompt:
         tmp_session.add_all([track_a, track_b])
         tmp_session.flush()
 
-        dup_cli._keep_a(track_a, track_b)
+        dup_cli._keep_a(tmp_session, track_a, track_b)
 
         db_track = tmp_session.query(Track).one()
         assert db_track.title == "a"
@@ -54,7 +59,7 @@ class TestPrompt:
         tmp_session.add_all([track_a, track_b])
         tmp_session.flush()
 
-        dup_cli._keep_b(track_a, track_b)
+        dup_cli._keep_b(tmp_session, track_a, track_b)
 
         db_track = tmp_session.query(Track).one()
         assert db_track.title == "b"
@@ -67,7 +72,7 @@ class TestPrompt:
         tmp_session.add_all([track_a, track_b])
         tmp_session.flush()
 
-        dup_cli._merge(track_a, track_b)
+        dup_cli._merge(tmp_session, track_a, track_b)
 
         db_track = tmp_session.query(Track).one()
         assert db_track.title == "b"
@@ -81,7 +86,7 @@ class TestPrompt:
         tmp_session.add_all([track_a, track_b])
         tmp_session.flush()
 
-        dup_cli._overwrite(track_a, track_b)
+        dup_cli._overwrite(tmp_session, track_a, track_b)
 
         db_track = tmp_session.query(Track).one()
         assert db_track.title == "a"

--- a/tests/duplicate/test_dup_core.py
+++ b/tests/duplicate/test_dup_core.py
@@ -6,7 +6,7 @@ import pytest
 
 import moe
 from moe import remove
-from moe.config import ExtraPlugin, MoeSession
+from moe.config import ExtraPlugin
 from moe.library import Album, Extra, Track
 from tests.conftest import album_factory, extra_factory, track_factory
 
@@ -16,13 +16,13 @@ class DuplicatePlugin:
 
     @staticmethod
     @moe.hookimpl
-    def resolve_dup_items(item_a, item_b):
+    def resolve_dup_items(session, item_a, item_b):
         """Resolve duplicates."""
         if isinstance(item_a, (Track, Album)):
             if item_a.title == "remove me":
-                remove.remove_item(item_a)
+                remove.remove_item(session, item_a)
             if item_b.title == "remove me":
-                remove.remove_item(item_b)
+                remove.remove_item(session, item_b)
             if item_a.title == "change me":
                 dest = item_a.path.parent / "new.mp3"
                 shutil.copyfile(item_a.path, dest)
@@ -45,103 +45,96 @@ def _tmp_dup_config(tmp_config):
 class TestResolveDupItems:
     """Test ``resolve_dup_items()``."""
 
-    def test_remove_a(self):
+    def test_remove_a(self, tmp_session):
         """Remove a track."""
         track_a = track_factory(exists=True, title="remove me")
         track_b = track_factory(exists=True, path=track_a.path)
 
-        session = MoeSession()
-        session.add(track_a)
-        session.add(track_b)
-        session.flush()
+        tmp_session.add(track_a)
+        tmp_session.add(track_b)
+        tmp_session.flush()
 
-        db_track = session.query(Track).one()
+        db_track = tmp_session.query(Track).one()
         assert db_track == track_b
 
-    def test_remove_b(self):
+    def test_remove_b(self, tmp_session):
         """Remove b track."""
         track_a = track_factory(exists=True)
         track_b = track_factory(exists=True, path=track_a.path, title="remove me")
 
-        session = MoeSession()
-        session.add(track_a)
-        session.add(track_b)
-        session.flush()
+        tmp_session.add(track_a)
+        tmp_session.add(track_b)
+        tmp_session.flush()
 
-        db_track = session.query(Track).one()
+        db_track = tmp_session.query(Track).one()
         assert db_track == track_a
 
-    def test_rm_existing_track(self):
+    def test_rm_existing_track(self, tmp_session):
         """Remove b track."""
         track_a = track_factory(exists=True, title="remove me")
         track_b = track_factory(exists=True, path=track_a.path)
 
-        session = MoeSession()
-        session.add(track_a)
-        session.flush()
-        session.add(track_b)
-        session.flush()
+        tmp_session.add(track_a)
+        tmp_session.flush()
+        tmp_session.add(track_b)
+        tmp_session.flush()
 
-        db_track = session.query(Track).one()
+        db_track = tmp_session.query(Track).one()
         assert db_track == track_b
 
-    def test_changing_fields(self):
+    def test_changing_fields(self, tmp_session):
         """Duplicates can be avoided by changing conflicting fields."""
         track_a = track_factory(exists=True, title="change me")
         track_b = track_factory(exists=True, path=track_a.path)
 
-        session = MoeSession()
-        session.add(track_a)
-        session.add(track_b)
-        session.flush()
+        tmp_session.add(track_a)
+        tmp_session.add(track_b)
+        tmp_session.flush()
 
-        db_tracks = session.query(Track).all()
+        db_tracks = tmp_session.query(Track).all()
         assert track_a in db_tracks
         assert track_b in db_tracks
 
-    def test_change_extra(self):
+    def test_change_extra(self, tmp_session):
         """Duplicate extras can be avoided."""
         extra_a = extra_factory(exists=True)
         extra_b = extra_factory(exists=True, path=extra_a.path)
 
-        session = MoeSession()
-        session.add(extra_a)
-        session.add(extra_b)
-        session.flush()
+        tmp_session.add(extra_a)
+        tmp_session.add(extra_b)
+        tmp_session.flush()
 
-        db_extras = session.query(Extra).all()
+        db_extras = tmp_session.query(Extra).all()
         assert extra_a in db_extras
         assert extra_b in db_extras
 
-    def test_remove_album(self):
+    def test_remove_album(self, tmp_session):
         """Remove an album."""
         album_a = album_factory(exists=True, title="remove me")
         album_b = album_factory(exists=True, path=album_a.path)
 
-        session = MoeSession()
-        session.add(album_a)
-        session.add(album_b)
-        session.flush()
+        tmp_session.add(album_a)
+        tmp_session.add(album_b)
+        tmp_session.flush()
 
-        db_album = session.query(Album).one()
+        db_album = tmp_session.query(Album).one()
         assert db_album == album_b
 
-    def test_album_first(self):
+    def test_album_first(self, tmp_session):
         """Albums should be processed first as they may resolve tracks or extras too."""
         album_a = album_factory(exists=True, title="remove me")
         album_b = album_factory(exists=True, path=album_a.path)
         album_b.tracks[0].path = album_a.tracks[0].path
         album_a.tracks[0].title = "change me"  # shouldn't get changed as
 
-        session = MoeSession()
-        session.add(album_a.tracks[0])
-        session.add(album_b.tracks[0])
-        session.add(album_a)
-        session.add(album_b)
-        session.flush()
+        tmp_session.add(album_a.tracks[0])
+        tmp_session.add(album_b.tracks[0])
+        tmp_session.add(album_a)
+        tmp_session.add(album_b)
+        tmp_session.flush()
 
-        db_album = session.query(Album).one()
+        db_album = tmp_session.query(Album).one()
         assert db_album == album_b
-        db_tracks = session.query(Track).all()
+        db_tracks = tmp_session.query(Track).all()
         for track in db_tracks:
             assert track.title != "changed"

--- a/tests/edit/test_edit_cli.py
+++ b/tests/edit/test_edit_cli.py
@@ -2,7 +2,7 @@
 
 from types import FunctionType
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -50,7 +50,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", query_type="track")
         mock_edit.assert_called_once_with(track, "track_num", "3")
 
     def test_album(self, mock_query, mock_edit):
@@ -61,7 +61,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="album")
+        mock_query.assert_called_once_with(ANY, "*", query_type="album")
         mock_edit.assert_called_once_with(album, "title", "edit")
 
     def test_extra(self, mock_query, mock_edit):
@@ -72,7 +72,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="extra")
+        mock_query.assert_called_once_with(ANY, "*", query_type="extra")
         mock_edit.assert_called_once_with(extra, "title", "edit")
 
     def test_multiple_items(self, mock_query, mock_edit):

--- a/tests/library/test_lib_item.py
+++ b/tests/library/test_lib_item.py
@@ -1,7 +1,7 @@
 """Test shared library functionality."""
 
 import moe
-from moe.config import ExtraPlugin, MoeSession
+from moe.config import ExtraPlugin, moe_sessionmaker
 from moe.library import Album, Extra, Track
 from tests.conftest import album_factory, extra_factory, track_factory
 
@@ -11,35 +11,35 @@ class LibItemPlugin:
 
     @staticmethod
     @moe.hookimpl
-    def edit_changed_items(items):
+    def edit_changed_items(session, items):
         """Edit changed items."""
         for item in items:
             item.custom["changed"] = "edited"
 
     @staticmethod
     @moe.hookimpl
-    def edit_new_items(items):
+    def edit_new_items(session, items):
         """Edit new items."""
         for item in items:
             item.custom["new"] = "edited"
 
     @staticmethod
     @moe.hookimpl
-    def process_changed_items(items):
+    def process_changed_items(session, items):
         """Process changed items."""
         for item in items:
             item.custom["changed"] = "processed"
 
     @staticmethod
     @moe.hookimpl
-    def process_new_items(items):
+    def process_new_items(session, items):
         """Process new items."""
         for item in items:
             item.custom["new"] = "processed"
 
     @staticmethod
     @moe.hookimpl
-    def process_removed_items(items):
+    def process_removed_items(session, items):
         """Process removed items."""
         for item in items:
             item.custom["removed"] = "processed"
@@ -59,7 +59,7 @@ class TestHooks:
         extra = extra_factory()
         track = track_factory()
 
-        session = MoeSession()
+        session = moe_sessionmaker()
         session.add(album)
         session.add(extra)
         session.add(track)
@@ -85,7 +85,7 @@ class TestHooks:
         extra = extra_factory()
         track = track_factory()
 
-        session = MoeSession()
+        session = moe_sessionmaker()
         session.add(album)
         session.add(extra)
         session.add(track)
@@ -106,7 +106,7 @@ class TestHooks:
         extra = extra_factory()
         track = track_factory()
 
-        session = MoeSession()
+        session = moe_sessionmaker()
         session.add(album)
         session.add(extra)
         session.add(track)
@@ -137,7 +137,7 @@ class TestHooks:
         extra = extra_factory()
         track = track_factory()
 
-        session = MoeSession()
+        session = moe_sessionmaker()
         session.add(album)
         session.add(extra)
         session.add(track)
@@ -164,7 +164,7 @@ class TestHooks:
         extra = extra_factory(album=album)
         track = track_factory(album=album)
 
-        session = MoeSession()
+        session = moe_sessionmaker()
         session.add(album)
         session.add(extra)
         session.add(track)
@@ -206,7 +206,7 @@ class TestCustomFields:
             db="persists", my_list=["wow", "change me"], growing_list=["one"]
         )
 
-        session = MoeSession()
+        session = moe_sessionmaker()
         session.add(track)
         session.commit()
         track.custom["db"] = "persisted"

--- a/tests/move/test_move_cli.py
+++ b/tests/move/test_move_cli.py
@@ -2,7 +2,7 @@
 
 from types import FunctionType
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -50,7 +50,7 @@ class TestCommand:
         moe.cli.main(cli_args)
 
         mock_move.assert_not_called()
-        mock_query.assert_called_once_with("*", "album")
+        mock_query.assert_called_once_with(ANY, "*", "album")
 
     def test_move(self, mock_query, mock_move):
         """Test all items in the library are moved when the command is invoked."""
@@ -63,7 +63,7 @@ class TestCommand:
         for album in albums:
             mock_move.assert_any_call(album)
         assert mock_move.call_count == len(albums)
-        mock_query.assert_called_once_with("*", "album")
+        mock_query.assert_called_once_with(ANY, "*", "album")
 
 
 class TestPluginRegistration:

--- a/tests/move/test_move_core.py
+++ b/tests/move/test_move_core.py
@@ -1,6 +1,6 @@
 """Tests the core api for moving items."""
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -476,21 +476,27 @@ class TestEditNewItems:
     def test_album(self, mock_copy):
         """Albums are copied after they are added to the library."""
         album = album_factory()
-        config.CONFIG.pm.hook.edit_new_items(items=[album])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.edit_new_items(session=mock_session, items=[album])
 
         mock_copy.assert_called_once_with(album)
 
     def test_track(self, mock_copy):
         """Tracks are copied after they are added to the library."""
         track = track_factory()
-        config.CONFIG.pm.hook.edit_new_items(items=[track])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.edit_new_items(session=mock_session, items=[track])
 
         mock_copy.assert_called_once_with(track)
 
     def test_extra(self, mock_copy):
         """Extras are copied after they are added to the library."""
         extra = extra_factory()
-        config.CONFIG.pm.hook.edit_new_items(items=[extra])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.edit_new_items(session=mock_session, items=[extra])
 
         mock_copy.assert_called_once_with(extra)
 

--- a/tests/read/test_read_cli.py
+++ b/tests/read/test_read_cli.py
@@ -2,7 +2,7 @@
 
 from types import FunctionType
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -48,7 +48,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", query_type="track")
         mock_read.assert_called_once_with(track)
 
     def test_album(self, mock_query, mock_read):
@@ -59,7 +59,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="album")
+        mock_query.assert_called_once_with(ANY, "*", query_type="album")
         mock_read.assert_called_once_with(album)
 
     def test_multiple_items(self, mock_query, mock_read):
@@ -70,7 +70,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", query_type="track")
         for track in tracks:
             mock_read.assert_any_call(track)
         assert mock_read.call_count == 2
@@ -108,7 +108,7 @@ class TestCommand:
         with patch("moe.read.read_cli.remove.remove_item") as mock_rm:
             moe.cli.main(cli_args)
 
-        mock_rm.assert_called_once_with(track)
+        mock_rm.assert_called_once_with(ANY, track)
 
 
 class TestPluginRegistration:

--- a/tests/remove/test_rm_cli.py
+++ b/tests/remove/test_rm_cli.py
@@ -2,7 +2,7 @@
 
 from types import FunctionType
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -48,8 +48,8 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="track")
-        mock_rm.assert_called_once_with(track)
+        mock_query.assert_called_once_with(ANY, "*", query_type="track")
+        mock_rm.assert_called_once_with(ANY, track)
 
     def test_album(self, mock_query, mock_rm):
         """Albums are removed from the database with valid query."""
@@ -59,8 +59,8 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="album")
-        mock_rm.assert_called_once_with(album)
+        mock_query.assert_called_once_with(ANY, "*", query_type="album")
+        mock_rm.assert_called_once_with(ANY, album)
 
     def test_extra(self, mock_query, mock_rm):
         """Extras are removed from the database with valid query."""
@@ -70,8 +70,8 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="extra")
-        mock_rm.assert_called_once_with(extra)
+        mock_query.assert_called_once_with(ANY, "*", query_type="extra")
+        mock_rm.assert_called_once_with(ANY, extra)
 
     def test_multiple_items(self, mock_query, mock_rm):
         """All items returned from the query are removed."""
@@ -82,7 +82,7 @@ class TestCommand:
         moe.cli.main(cli_args)
 
         for track in tracks:
-            mock_rm.assert_any_call(track)
+            mock_rm.assert_any_call(ANY, track)
         assert mock_rm.call_count == 2
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 import moe
 import moe.cli
 from moe import config
+from moe.config import moe_sessionmaker
 from moe.library import Track
 from tests.conftest import track_factory
 
@@ -31,8 +32,7 @@ def test_commit_on_systemexit(tmp_config):
 
     assert error.value.code != 0
 
-    session = config.MoeSession()
-    with session.begin():
+    with moe_sessionmaker.begin() as session:
         session.query(Track).one()
 
 
@@ -42,8 +42,7 @@ def test_default_config(tmp_config):
     tmp_config(settings="default_plugins = ['cli', 'write', 'list']", init_db=True)
     track = track_factory(exists=True)
 
-    session = config.MoeSession()
-    with session.begin():
+    with moe_sessionmaker.begin() as session:
         session.add(track)
 
     moe.cli.main(cli_args)
@@ -69,7 +68,7 @@ class CLIPlugin:
     def add_command(cmd_parsers):
         """Add a `cli` command to Moe."""
 
-        def say_hello(args):
+        def say_hello(session, args):
             print("hello")
 
         cli_parser = cmd_parsers.add_parser("cli")

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -2,7 +2,7 @@
 
 from types import FunctionType
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -41,7 +41,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", query_type="track")
         assert capsys.readouterr().out.strip("\n") == str(track)
 
     def test_album(self, capsys, mock_query):
@@ -52,7 +52,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="album")
+        mock_query.assert_called_once_with(ANY, "*", query_type="album")
         assert capsys.readouterr().out.strip("\n") == str(album)
 
     def test_extra(self, capsys, mock_query):
@@ -63,7 +63,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="extra")
+        mock_query.assert_called_once_with(ANY, "*", query_type="extra")
         assert capsys.readouterr().out.strip("\n") == str(extra)
 
     def test_multiple_items(self, capsys, mock_query):
@@ -85,7 +85,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with("*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", query_type="track")
         assert capsys.readouterr().out.strip("\n") == str(track.path)
 
     def test_info_album(self, mock_query):

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,7 +1,7 @@
 """Tests the ``write`` plugin."""
 
 import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import mediafile
 import pytest
@@ -124,27 +124,38 @@ class TestProcessNewItems:
     def test_process_track(self, mock_write):
         """Any altered Tracks have their tags written."""
         track = track_factory()
-        config.CONFIG.pm.hook.process_new_items(items=[track])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.process_new_items(session=mock_session, items=[track])
 
         mock_write.assert_called_once_with(track)
 
     def test_process_extra(self, mock_write):
         """Any altered extras are ignored."""
-        config.CONFIG.pm.hook.process_new_items(items=[extra_factory()])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.process_new_items(
+            session=mock_session, items=[extra_factory()]
+        )
 
         mock_write.assert_not_called()
 
     def test_process_album(self, mock_write):
         """Any altered albums are ignored."""
-        config.CONFIG.pm.hook.process_new_items(items=[album_factory()])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.process_new_items(
+            session=mock_session, items=[album_factory()]
+        )
 
         mock_write.assert_not_called()
 
     def test_process_multiple_tracks(self, mock_write):
         """All altered tracks are written."""
         tracks = [track_factory(), track_factory()]
+        mock_session = MagicMock()
 
-        config.CONFIG.pm.hook.process_new_items(items=tracks)
+        config.CONFIG.pm.hook.process_new_items(session=mock_session, items=tracks)
 
         for track in tracks:
             mock_write.assert_any_call(track)
@@ -158,20 +169,28 @@ class TestProcessChangedItems:
     def test_process_track(self, mock_write):
         """Any altered Tracks have their tags written."""
         track = track_factory()
-        config.CONFIG.pm.hook.process_changed_items(items=[track])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.process_changed_items(session=mock_session, items=[track])
 
         mock_write.assert_called_once_with(track)
 
     def test_process_extra(self, mock_write):
         """Any altered extras are ignored."""
-        config.CONFIG.pm.hook.process_changed_items(items=[extra_factory()])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.process_changed_items(
+            session=mock_session, items=[extra_factory()]
+        )
 
         mock_write.assert_not_called()
 
     def test_process_album(self, mock_write):
         """Any altered albums should have their tracks written."""
         album = album_factory()
-        config.CONFIG.pm.hook.process_changed_items(items=[album])
+        mock_session = MagicMock()
+
+        config.CONFIG.pm.hook.process_changed_items(session=mock_session, items=[album])
 
         for track in album.tracks:
             mock_write.assert_any_call(track)
@@ -179,8 +198,9 @@ class TestProcessChangedItems:
     def test_process_multiple_tracks(self, mock_write):
         """All altered tracks are written."""
         tracks = [track_factory(), track_factory()]
+        mock_session = MagicMock()
 
-        config.CONFIG.pm.hook.process_changed_items(items=tracks)
+        config.CONFIG.pm.hook.process_changed_items(session=mock_session, items=tracks)
 
         for track in tracks:
             mock_write.assert_any_call(track)
@@ -189,7 +209,10 @@ class TestProcessChangedItems:
     def test_dont_write_tracks_twice(self, mock_write):
         """Don't write a track twice if it's album is also in `items`."""
         track = track_factory()
+        mock_session = MagicMock()
 
-        config.CONFIG.pm.hook.process_changed_items(items=[track, track.album])
+        config.CONFIG.pm.hook.process_changed_items(
+            session=mock_session, items=[track, track.album]
+        )
 
         mock_write.assert_called_once_with(track)

--- a/tests/util/cli/test_query.py
+++ b/tests/util/cli/test_query.py
@@ -2,7 +2,7 @@
 
 from types import FunctionType
 from typing import Iterator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -29,19 +29,21 @@ class TestCLIQuery:
     def test_bad_query(self, mock_query):
         """Exit with non-zero code if bad query given."""
         mock_query.side_effect = QueryError
+        mock_session = MagicMock()
 
         with pytest.raises(SystemExit) as error:
-            cli_query("bad query", "track")
+            cli_query(mock_session, "bad query", "track")
 
         assert error.value.code != 0
-        mock_query.assert_called_once_with("bad query", "track")
+        mock_query.assert_called_once_with(mock_session, "bad query", "track")
 
     def test_empty_query(self, mock_query):
         """Exit with non-zero code if bad query given."""
         mock_query.return_value = []
+        mock_session = MagicMock()
 
         with pytest.raises(SystemExit) as error:
-            cli_query("*", "track")
+            cli_query(mock_session, "*", "track")
 
         assert error.value.code != 0
-        mock_query.assert_called_once_with("*", "track")
+        mock_query.assert_called_once_with(mock_session, "*", "track")


### PR DESCRIPTION
This helps clarify exactly which functions require the database to be initialized. Also, it helps avoid any potential future issues with relying entirely on a global/thread-local session factory.


<!-- readthedocs-preview mrmoe start -->
----
:books: Documentation preview :books:: https://mrmoe--252.org.readthedocs.build/en/252/

<!-- readthedocs-preview mrmoe end -->