### PR TITLE
docs: fix env var used to override the config dir

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,7 +6,7 @@ Configuration
 Moe will automatically create a config file, ``config.toml``, in ``$HOME/.config/moe`` or ``%USERPROFILE%\.config\moe`` if you're on Windows. This directory is also where your library database file will reside.
 
 .. note::
-    The configuration directory can be overwritten by setting the environment variable ``MOE_CONFIG.CONFIG_DIR``.
+    The configuration directory can be overwritten by setting the environment variable ``MOE_CONFIG_DIR``.
 
 Throughout this documentation, all configuration options will be displayed in the following format:
 


### PR DESCRIPTION
<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [ ] I have read the contributing guide in the documentation.

<!-- Description of the changes this pull request makes. -->
### Description

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--279.org.readthedocs.build/en/279/

<!-- readthedocs-preview mrmoe end -->