### PR TITLE
feat(move): Add `override_album_path_config` hook

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -89,6 +89,9 @@ Paths are formatted using python `f-strings <https://docs.python.org/3/tutorial/
     - For any path formatting changes, run ``moe move -n`` for a dry-run to avoid any unexpected results.
     - For a more detailed look at all the field options and types, take a look at the :ref:`library api <Library API>`. ``album``, ``track``, and ``extra`` in the path formats are ``Album``, ``Track``, and ``Extra`` objects respectively and thus you can reference any of their available attributes.
 
+.. note::
+    The ``album_path`` configuration can be completely overridden by plugins using the :meth:`~moe.move.move_core.Hooks.override_album_path_config` hook. This allows dynamic path structures based on album properties, such as redirecting classical albums or soundtracks to separate directory structures.
+
 Custom Path Template Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Moe allows plugins to create custom path template functions that can be called within the path templates. The function called in the default ``extra_path`` template, ``e_unique``, is an example of a custom path template function. The following custom template functions are included in the move plugin:

--- a/tests/move/test_move_core.py
+++ b/tests/move/test_move_core.py
@@ -1,6 +1,7 @@
 """Tests the core api for moving items."""
 
 from pathlib import Path
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,8 @@ import pytest
 import moe
 from moe import config
 from moe import move as moe_move
+from moe.config import ExtraPlugin
+from moe.library import Album
 from tests.conftest import album_factory, extra_factory, track_factory
 
 
@@ -510,3 +513,87 @@ class TestPluginRegistration:
         tmp_config(settings='default_plugins = ["move"]')
 
         assert config.CONFIG.pm.has_plugin("move_core")
+
+
+class TestPluginOverrideAlbumPathConfig:
+    """Test plugin that implements the override_album_path_config hook."""
+
+    @staticmethod
+    @moe.hookimpl
+    def override_album_path_config(album: Album) -> Optional[str]:
+        """Override the `album_path` for classical music albums."""
+        if "Classical" in album.title:
+            return "Classical/{album.artist}/{album.title}"
+
+
+class TestOverrideAlbumPathConfig:
+    """Test the `override_album_path_config` hook implementation."""
+
+    @pytest.fixture
+    def _tmp_album_path_config(self, tmp_config):
+        """Create a temporary configuration with the test plugin."""
+        tmp_config(
+            settings="""
+            default_plugins = ["move"]
+            [move]
+            album_path = "{album.artist}/{album.title}"
+            """,
+            extra_plugins=[
+                ExtraPlugin(
+                    TestPluginOverrideAlbumPathConfig, "override_album_path_plugin"
+                )
+            ],
+        )
+
+    @pytest.mark.usefixtures("_tmp_album_path_config")
+    def test_classical_album(self):
+        """Test that classical albums use the artist in the path."""
+        album = album_factory(
+            artist="Antonín Dvořák",
+            title="Classical Symphony No. 6",
+        )
+
+        path = moe_move.fmt_item_path(album)
+        expected_path = (
+            Path(moe.config.CONFIG.settings.library_path).expanduser()
+            / "Classical"
+            / "Antonín Dvořák"
+            / "Classical Symphony No. 6"
+        )
+
+        assert path == expected_path
+
+    @pytest.mark.usefixtures("_tmp_album_path_config")
+    def test_other_genre_album(self):
+        """Test that other albums use the default path configuration."""
+        album = album_factory(artist="Foreigner", title="Double Vision")
+
+        path = moe_move.fmt_item_path(album)
+        expected_path = (
+            Path(moe.config.CONFIG.settings.library_path).expanduser()
+            / "Foreigner"
+            / "Double Vision"
+        )
+
+        assert path == expected_path
+
+    def test_no_plugin(self, tmp_config):
+        """Test that the default configuration is used when no plugin is active."""
+        tmp_config(
+            settings="""
+            default_plugins = ["move"]
+            [move]
+            album_path = "{album.artist}/{album.title}"
+            """
+        )
+
+        album = album_factory(artist="Antonín Dvořák", title="Classical Symphony No. 6")
+
+        path = moe_move.fmt_item_path(album)
+        expected_path = (
+            Path(moe.config.CONFIG.settings.library_path).expanduser()
+            / "Antonín Dvořák"
+            / "Classical Symphony No. 6"
+        )
+
+        assert path == expected_path


### PR DESCRIPTION
- [x] I have read the contributing guide in the documentation.

### Description
This PR adds a new hook to the move plugin called `override_album_path_config` which allows plugins to modify the album path configuration dynamically based on the album's properties.

For more context, see discussion #231.

### Additional information

@jtpavlock I took a stab at implementing the `override_album_path_config` hook we discussed and added some tests which pass locally! But I'm not totally sure that I adhered to moe's design/coding philosophy as I'm still familiarizing myself with the code base. Would appreciate any feedback!

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--281.org.readthedocs.build/en/281/

<!-- readthedocs-preview mrmoe end -->