### PR TITLE
feat(edit): editing fields now allows for creation of new custom fields

### DIFF
--- a/moe/edit/edit_cli.py
+++ b/moe/edit/edit_cli.py
@@ -34,6 +34,12 @@ def add_command(cmd_parsers: argparse._SubParsersAction):
         epilog=epilog_help,
     )
     edit_parser.add_argument(
+        "-c",
+        "--create",
+        action="store_true",
+        help="creates the field if it doesn't already exist",
+    )
+    edit_parser.add_argument(
         "fv_terms", metavar="FIELD=VALUE", nargs="+", help="set FIELD to VALUE"
     )
     edit_parser.set_defaults(func=_parse_args)
@@ -63,7 +69,7 @@ def _parse_args(session: Session, args: argparse.Namespace):
 
         for item in items:
             try:
-                edit.edit_item(item, field, value)
+                edit.edit_item(item, field, value, args.create)
             except edit.EditError as err:
                 log.error(err)
                 error_count += 1

--- a/moe/edit/edit_core.py
+++ b/moe/edit/edit_core.py
@@ -17,13 +17,15 @@ class EditError(Exception):
     """Error editing an item in the library."""
 
 
-def edit_item(item: LibItem, field: str, value: str):  # noqa: C901
+def edit_item(item: LibItem, field: str, value: str, create_field=False):  # noqa: C901
     """Sets a LibItem's ``field`` to ``value``.
 
     Args:
         item: Library item to edit.
         field: Item field to edit.
         value: Value to set the item's field to.
+        create_field: Whether to create ``field`` as a new custom field if it doesn't
+            already exist.
 
     Raises:
         EditError: ``field`` is not a valid attribute or is not editable.
@@ -36,7 +38,7 @@ def edit_item(item: LibItem, field: str, value: str):  # noqa: C901
     try:
         attr = getattr(item.__class__, field)
     except AttributeError as a_err:
-        if field in item.custom:
+        if create_field or field in item.custom:
             item.custom[field] = value
             return
 

--- a/tests/edit/test_edit_cli.py
+++ b/tests/edit/test_edit_cli.py
@@ -51,7 +51,7 @@ class TestCommand:
         moe.cli.main(cli_args)
 
         mock_query.assert_called_once_with(ANY, "*", query_type="track")
-        mock_edit.assert_called_once_with(track, "track_num", "3")
+        mock_edit.assert_called_once_with(track, "track_num", "3", create_field=False)
 
     def test_album(self, mock_query, mock_edit):
         """Albums are edited."""
@@ -62,7 +62,7 @@ class TestCommand:
         moe.cli.main(cli_args)
 
         mock_query.assert_called_once_with(ANY, "*", query_type="album")
-        mock_edit.assert_called_once_with(album, "title", "edit")
+        mock_edit.assert_called_once_with(album, "title", "edit", create_field=False)
 
     def test_extra(self, mock_query, mock_edit):
         """Extras are edited."""
@@ -73,7 +73,7 @@ class TestCommand:
         moe.cli.main(cli_args)
 
         mock_query.assert_called_once_with(ANY, "*", query_type="extra")
-        mock_edit.assert_called_once_with(extra, "title", "edit")
+        mock_edit.assert_called_once_with(extra, "title", "edit", create_field=False)
 
     def test_multiple_items(self, mock_query, mock_edit):
         """All items returned from a query are edited."""
@@ -84,8 +84,8 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_edit.assert_any_call(track1, "track_num", "3")
-        mock_edit.assert_any_call(track2, "track_num", "3")
+        mock_edit.assert_any_call(track1, "track_num", "3", create_field=False)
+        mock_edit.assert_any_call(track2, "track_num", "3", create_field=False)
         assert mock_edit.call_count == 2
 
     def test_multiple_terms(self, mock_query, mock_edit):
@@ -96,8 +96,8 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_edit.assert_any_call(track, "track_num", "3")
-        mock_edit.assert_any_call(track, "title", "yo")
+        mock_edit.assert_any_call(track, "track_num", "3", create_field=False)
+        mock_edit.assert_any_call(track, "title", "yo", create_field=False)
         assert mock_edit.call_count == 2
 
     def test_invalid_fv_term(self, mock_query):
@@ -121,7 +121,7 @@ class TestCommand:
             moe.cli.main(cli_args)
 
         assert error.value.code != 0
-        mock_edit.assert_called_once_with(track, "track_num", "3")
+        mock_edit.assert_called_once_with(track, "track_num", "3", create_field=False)
 
     def test_edit_error(self, mock_query, mock_edit):
         """Raise SystemExit if there is an error editing the item."""
@@ -134,6 +134,16 @@ class TestCommand:
             moe.cli.main(cli_args)
 
         assert error.value.code != 0
+
+    def test_create_new_custom_field(self, mock_query, mock_edit):
+        """Create a new custom field if given '-c' and it doesn't exist."""
+        track = track_factory()
+        cli_args = ["edit", "-c", "*", "track_num=3"]
+        mock_query.return_value = [track]
+
+        moe.cli.main(cli_args)
+
+        mock_edit.assert_called_once_with(track, "track_num", "3", create_field=True)
 
 
 class TestPluginRegistration:

--- a/tests/edit/test_edit_core.py
+++ b/tests/edit/test_edit_core.py
@@ -80,6 +80,13 @@ class TestEditItem:
 
         assert track.custom["my_title"] == "new"
 
+    def test_create_custom_field(self):
+        """We can create a new custom field and set it if specified."""
+        track = track_factory()
+        edit.edit_item(track, "my_title", "new", create_field=True)
+
+        assert track.custom["my_title"] == "new"
+
 
 class TestPluginRegistration:
     """Test the `plugin_registration` hook implementation."""


### PR DESCRIPTION
In the CLI, when editing a field that doesn't exist, moe will give an error. The user now has the option to specify to override this behavior and create the missing field with the `-c` or `--create` flag e.g. `moe edit -c "*" my_new_field=fun`.

This also introduces a new flag to the `edit.edit_item` api command.

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--288.org.readthedocs.build/en/288/

<!-- readthedocs-preview mrmoe end -->