### PR TITLE
fix(move): prevent duplicate copying of tracks and extras when processing albums

### DIFF
--- a/moe/move/move_core.py
+++ b/moe/move/move_core.py
@@ -69,7 +69,11 @@ def add_config_validator(settings: dynaconf.base.LazySettings):
 def edit_new_items(items: list[LibItem]):
     """Copies and formats the path of an item after it has been added to the library."""
     for item in items:
-        copy_item(item)
+        # Only copy tracks and extras if their album is not also being processed.
+        # This prevents double-copying since _copy_album already handles all
+        # tracks/extras.
+        if not (isinstance(item, (Track, Extra)) and item.album in items):
+            copy_item(item)
 
 
 @moe.hookimpl

--- a/tests/move/test_move_core.py
+++ b/tests/move/test_move_core.py
@@ -501,6 +501,17 @@ class TestEditNewItems:
 
         mock_copy.assert_called_once_with(extra)
 
+    def test_album_with_tracks_and_extras_no_duplicate_copy(self, mock_copy):
+        """Avoid duplicate copying when album and its items are batched."""
+        album = album_factory(num_tracks=2, num_extras=2)
+        mock_session = MagicMock()
+
+        items = [album] + album.tracks + album.extras
+
+        config.CONFIG.pm.hook.edit_new_items(session=mock_session, items=items)
+
+        mock_copy.assert_called_once_with(album)
+
 
 class TestPluginRegistration:
     """Test the `plugin_registration` hook implementation."""


### PR DESCRIPTION
- [x] I have read the contributing guide in the documentation.

### Description

Updated the `edit_new_items` function to skip copying tracks and extras if their album is already being processed, ensuring no duplicates occur.

This PR is addressing the issue raised in discussion #280.

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--294.org.readthedocs.build/en/294/

<!-- readthedocs-preview mrmoe end -->