### PR TITLE
feat(track): add `composer` and `composer_sort` fields

### DIFF
--- a/docs/developers/contributing.rst
+++ b/docs/developers/contributing.rst
@@ -140,12 +140,12 @@ If adding a new field to Moe, the following checklist can help ensure you cover 
    * If the field represents metadata and does not deal with the filesystem, also add to the appropriate ``Meta`` class (``MetaAlbum`` or ``MetaTrack``).
    * If creating a multi-value field, add the non-plural equivalent property. See ``Track.genres`` and the accompanying single-value field, ``Track.genre`` for an example.
    * Include documentation for the new field in the class docstring(s).
+#. Add the new field to the appropriate library item's ``__init__`` method.
 
+   * If the field represents metadata and does not deal with the filesystem, also add to the appropriate ``Meta`` class (``MetaAlbum`` or ``MetaTrack``).
+   * Add tests for constructing an item with the new field in the appropriate test file's ``TestInit`` and ``TestMetaInit`` classes.
 #. Add to the item's ``fields`` method as necessary.
 #. Add code for reading the tag from a track file under ``Track.read_custom_tags``.
-
-   * Add tests under ``test_track.py:TestFromFile:test_read_tags()``
-
 #. Add code for writing the tag to a track file under ``write.write_custom_tags``.
 
    * Add tests under ``test_write.py:TestWriteTags:test_write_tags()``

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -13,6 +13,7 @@ Track Fields
 * ``artists`` - track artists [#f1]_
 * ``audio_format`` - aac, aiff, alac, ape, asf, dsf, flac, ogg, opus, mp3, mpc, wav, or wv [#f3]_ [#f4]_
 * ``bit_depth`` - number of bits per sample in the audio encoding [#f3]_ [#f4]_
+* ``composer`` - track composer
 * ``disc`` - disc number
 * ``genre`` - genre [#f1]_
 * ``path`` - filesystem path of the track [#f3]_

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -14,6 +14,7 @@ Track Fields
 * ``audio_format`` - aac, aiff, alac, ape, asf, dsf, flac, ogg, opus, mp3, mpc, wav, or wv [#f3]_ [#f4]_
 * ``bit_depth`` - number of bits per sample in the audio encoding [#f3]_ [#f4]_
 * ``composer`` - track composer
+* ``composer_sort`` - composer sort field
 * ``disc`` - disc number
 * ``genre`` - genre [#f1]_
 * ``path`` - filesystem path of the track [#f3]_

--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -102,6 +102,7 @@ def read_custom_tags(
     track_fields["artist"] = audio_file.artist
     if audio_file.artists is not None:
         track_fields["artists"] = set(audio_file.artists)
+    track_fields["composer"] = audio_file.composer
     track_fields["disc"] = audio_file.disc
     if audio_file.genres is not None:
         track_fields["genres"] = set(audio_file.genres)
@@ -124,6 +125,7 @@ class MetaTrack(MetaLibItem):
         album (Optional[Album]): Corresponding Album object.
         artist (Optional[str])
         artists (Optional[set[str]]): Set of all artists.
+        composer (Optional[str]): Track composer.
         custom (dict[str, Any]): Dictionary of custom fields.
         disc (Optional[int]): Disc number the track is on.
         genres (Optional[set[str]]): Set of all genres.
@@ -137,6 +139,7 @@ class MetaTrack(MetaLibItem):
         track_num: int,
         artist: Optional[str] = None,
         artists: Optional[set[str]] = None,
+        composer: Optional[str] = None,
         disc: int = 1,
         genres: Optional[set[str]] = None,
         title: Optional[str] = None,
@@ -151,6 +154,7 @@ class MetaTrack(MetaLibItem):
         self.track_num = track_num
         self.artist = artist or self.album.artist
         self.artists = artists
+        self.composer = composer
         self.disc = disc
         self.genres = genres
         self.title = title
@@ -184,6 +188,7 @@ class MetaTrack(MetaLibItem):
             "album",
             "artist",
             "artists",
+            "composer",
             "disc",
             "genres",
             "title",
@@ -274,6 +279,7 @@ class Track(LibItem, SABase, MetaTrack):
         album (Album): Corresponding Album object.
         artist (str)
         artists (Optional[set[str]]): Set of all artists.
+        composer (Optional[str]): Track composer.
         custom (dict[str, Any]): Dictionary of custom fields.
         disc (int): Disc number the track is on.
         genres (Optional[set[str]]): Set of all genres.
@@ -292,6 +298,7 @@ class Track(LibItem, SABase, MetaTrack):
     artists: Mapped[Optional[set[str]]] = mapped_column(
         MutableSet.as_mutable(SetType()), nullable=True
     )
+    composer: Mapped[Optional[str]]
     disc: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     genres: Mapped[Optional[set[str]]] = mapped_column(
         MutableSet.as_mutable(SetType()), nullable=True
@@ -315,6 +322,7 @@ class Track(LibItem, SABase, MetaTrack):
         track_num: int,
         artist: Optional[str] = None,
         artists: Optional[set[str]] = None,
+        composer: Optional[str] = None,
         disc: Optional[int] = None,
         genres: Optional[set[str]] = None,
         **kwargs,
@@ -328,6 +336,7 @@ class Track(LibItem, SABase, MetaTrack):
             track_num: Track number.
             artist: Track artist. Defaults to the album artist if not given.
             artists: Set of all artists.
+            composer: Track composer.
             disc: Disc the track belongs to. If not given, will try to guess the disc
                 based on the ``path`` of the track.
             genres (Optional[set[str]]): Set of all genres.
@@ -340,6 +349,7 @@ class Track(LibItem, SABase, MetaTrack):
         self.path = path
         self.artist = artist or self.album.artist
         self.artists = artists
+        self.composer = composer
         self.disc = disc or self._guess_disc()
         self.genres = genres
         self.title = title

--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -103,6 +103,7 @@ def read_custom_tags(
     if audio_file.artists is not None:
         track_fields["artists"] = set(audio_file.artists)
     track_fields["composer"] = audio_file.composer
+    track_fields["composer_sort"] = audio_file.composer_sort
     track_fields["disc"] = audio_file.disc
     if audio_file.genres is not None:
         track_fields["genres"] = set(audio_file.genres)
@@ -126,6 +127,7 @@ class MetaTrack(MetaLibItem):
         artist (Optional[str])
         artists (Optional[set[str]]): Set of all artists.
         composer (Optional[str]): Track composer.
+        composer_sort (Optional[str]): Composer sort field.
         custom (dict[str, Any]): Dictionary of custom fields.
         disc (Optional[int]): Disc number the track is on.
         genres (Optional[set[str]]): Set of all genres.
@@ -140,6 +142,7 @@ class MetaTrack(MetaLibItem):
         artist: Optional[str] = None,
         artists: Optional[set[str]] = None,
         composer: Optional[str] = None,
+        composer_sort: Optional[str] = None,
         disc: int = 1,
         genres: Optional[set[str]] = None,
         title: Optional[str] = None,
@@ -155,6 +158,7 @@ class MetaTrack(MetaLibItem):
         self.artist = artist or self.album.artist
         self.artists = artists
         self.composer = composer
+        self.composer_sort = composer_sort
         self.disc = disc
         self.genres = genres
         self.title = title
@@ -189,6 +193,7 @@ class MetaTrack(MetaLibItem):
             "artist",
             "artists",
             "composer",
+            "composer_sort",
             "disc",
             "genres",
             "title",
@@ -280,6 +285,7 @@ class Track(LibItem, SABase, MetaTrack):
         artist (str)
         artists (Optional[set[str]]): Set of all artists.
         composer (Optional[str]): Track composer.
+        composer_sort (Optional[str]): Composer sort field.
         custom (dict[str, Any]): Dictionary of custom fields.
         disc (int): Disc number the track is on.
         genres (Optional[set[str]]): Set of all genres.
@@ -299,6 +305,7 @@ class Track(LibItem, SABase, MetaTrack):
         MutableSet.as_mutable(SetType()), nullable=True
     )
     composer: Mapped[Optional[str]]
+    composer_sort: Mapped[Optional[str]]
     disc: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     genres: Mapped[Optional[set[str]]] = mapped_column(
         MutableSet.as_mutable(SetType()), nullable=True
@@ -323,6 +330,7 @@ class Track(LibItem, SABase, MetaTrack):
         artist: Optional[str] = None,
         artists: Optional[set[str]] = None,
         composer: Optional[str] = None,
+        composer_sort: Optional[str] = None,
         disc: Optional[int] = None,
         genres: Optional[set[str]] = None,
         **kwargs,
@@ -337,6 +345,7 @@ class Track(LibItem, SABase, MetaTrack):
             artist: Track artist. Defaults to the album artist if not given.
             artists: Set of all artists.
             composer: Track composer.
+            composer_sort: Composer sort field.
             disc: Disc the track belongs to. If not given, will try to guess the disc
                 based on the ``path`` of the track.
             genres (Optional[set[str]]): Set of all genres.
@@ -350,6 +359,7 @@ class Track(LibItem, SABase, MetaTrack):
         self.artist = artist or self.album.artist
         self.artists = artists
         self.composer = composer
+        self.composer_sort = composer_sort
         self.disc = disc or self._guess_disc()
         self.genres = genres
         self.title = title

--- a/moe/moe_alembic/versions/16590851e88e_new_field_composer_sort.py
+++ b/moe/moe_alembic/versions/16590851e88e_new_field_composer_sort.py
@@ -1,0 +1,26 @@
+"""new field: composer_sort.
+
+Revision ID: 16590851e88e
+Revises: 31e896e9a709
+Create Date: 2025-06-15 07:42:32.888489
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "16590851e88e"
+down_revision = "31e896e9a709"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("composer_sort", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.drop_column("composer_sort")

--- a/moe/moe_alembic/versions/31e896e9a709_new_field_composer.py
+++ b/moe/moe_alembic/versions/31e896e9a709_new_field_composer.py
@@ -1,0 +1,26 @@
+"""new field: composer.
+
+Revision ID: 31e896e9a709
+Revises: ab5db9861d30
+Create Date: 2025-06-15 07:32:44.896247
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "31e896e9a709"
+down_revision = "ab5db9861d30"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("composer", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.drop_column("composer")

--- a/moe/util/core/match.py
+++ b/moe/util/core/match.py
@@ -30,6 +30,7 @@ MATCH_ALBUM_FIELD_WEIGHTS = {
 }  # how much to weigh matches of various fields
 
 MATCH_TRACK_FIELD_WEIGHTS = {
+    "composer": 0.8,
     "disc": 0.3,
     "title": 0.7,
     "track_num": 0.9,

--- a/moe/write.py
+++ b/moe/write.py
@@ -83,6 +83,7 @@ def write_custom_tags(track: Track):
     audio_file.barcode = track.album.barcode
     audio_file.catalognums = track.album.catalog_nums
     audio_file.composer = track.composer
+    audio_file.composer_sort = track.composer_sort
     audio_file.country = track.album.country
     audio_file.date = track.album.date
     audio_file.disc = track.disc

--- a/moe/write.py
+++ b/moe/write.py
@@ -82,6 +82,7 @@ def write_custom_tags(track: Track):
     audio_file.artists = track.artists
     audio_file.barcode = track.album.barcode
     audio_file.catalognums = track.album.catalog_nums
+    audio_file.composer = track.composer
     audio_file.country = track.album.country
     audio_file.date = track.album.date
     audio_file.disc = track.disc

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -202,14 +202,6 @@ class TestFromFile:
         assert new_track.album.title == "custom album title"
         assert new_track.title == "custom track title"
 
-    def test_read_track_fields(self, tmp_config):
-        """Plugins can add additional album fields via the `read_album_fields` hook."""
-        tmp_config(extra_plugins=[ExtraPlugin(MyTrackPlugin, "track_plugin")])
-        track = track_factory(exists=True)
-        new_track = Track.from_file(track.path)
-
-        assert new_track.title == "custom track title"
-
     def test_missing_artist(self, tmp_config):
         """Raise ValueError if track is missing both an artist and albumartist."""
         tmp_config()

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -105,6 +105,20 @@ class TestInit:
 
         assert new_track.custom["custom"] == "custom"
 
+    def test_composer_fields(self):
+        """Composer fields can be assigned during initialization."""
+        track = track_factory()
+
+        new_track = Track(
+            track.album,
+            track.path,
+            track.title,
+            track.track_num,
+            composer="Antonín Leopold Dvořák",
+        )
+
+        assert new_track.composer == "Antonín Leopold Dvořák"
+
 
 class TestMetaInit:
     """Test MetaTrack initialization."""
@@ -122,6 +136,17 @@ class TestMetaInit:
         track = MetaTrack(album, 1, artist="use me")
 
         assert track.artist == "use me"
+
+    def test_composer_fields(self):
+        """Composer fields can be assigned during MetaTrack initialization."""
+        album = MetaAlbum(artist="test_artist")
+        track = MetaTrack(
+            album,
+            1,
+            composer="Jane Melody",
+        )
+
+        assert track.composer == "Jane Melody"
 
 
 class TestFromFile:
@@ -369,6 +394,38 @@ class TestMerge:
         track.merge(other_track)
 
         assert track.custom["custom"] == "new"
+
+    def test_composer_fields(self):
+        """Composer fields merge correctly."""
+        album = MetaAlbum(artist="album_artist")
+        track1 = MetaTrack(album, 1)
+        track2 = MetaTrack(
+            album,
+            1,
+            composer="Alex Harmony",
+        )
+
+        track1.merge(track2)
+
+        assert track1.composer == "Alex Harmony"
+
+    def test_composer_overwrite(self):
+        """Composer fields overwrite correctly when specified."""
+        album = MetaAlbum(artist="album_artist")
+        track1 = MetaTrack(
+            album,
+            1,
+            composer="Sam Rhythm",
+        )
+        track2 = MetaTrack(
+            album,
+            1,
+            composer="Taylor Beat",
+        )
+
+        track1.merge(track2, overwrite=True)
+
+        assert track1.composer == "Taylor Beat"
 
 
 class TestProperties:

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -105,8 +105,8 @@ class TestInit:
 
         assert new_track.custom["custom"] == "custom"
 
-    def test_composer_fields(self):
-        """Composer fields can be assigned during initialization."""
+    def test_composer_field(self):
+        """Composer field can be assigned during initialization."""
         track = track_factory()
 
         new_track = Track(
@@ -118,6 +118,20 @@ class TestInit:
         )
 
         assert new_track.composer == "Antonín Leopold Dvořák"
+
+    def test_composer_sort_field(self):
+        """Composer sort field can be assigned during initialization."""
+        track = track_factory()
+
+        new_track = Track(
+            track.album,
+            track.path,
+            track.title,
+            track.track_num,
+            composer_sort="Dvořák, Antonín Leopold",
+        )
+
+        assert new_track.composer_sort == "Dvořák, Antonín Leopold"
 
 
 class TestMetaInit:
@@ -137,8 +151,8 @@ class TestMetaInit:
 
         assert track.artist == "use me"
 
-    def test_composer_fields(self):
-        """Composer fields can be assigned during MetaTrack initialization."""
+    def test_composer_field(self):
+        """Composer field can be assigned during MetaTrack initialization."""
         album = MetaAlbum(artist="test_artist")
         track = MetaTrack(
             album,
@@ -147,6 +161,17 @@ class TestMetaInit:
         )
 
         assert track.composer == "Jane Melody"
+
+    def test_composer_sort_field(self):
+        """Composer sort field can be assigned during MetaTrack initialization."""
+        album = MetaAlbum(artist="test_artist")
+        track = MetaTrack(
+            album,
+            1,
+            composer_sort="Melody, Jane",
+        )
+
+        assert track.composer_sort == "Melody, Jane"
 
 
 class TestFromFile:
@@ -394,38 +419,6 @@ class TestMerge:
         track.merge(other_track)
 
         assert track.custom["custom"] == "new"
-
-    def test_composer_fields(self):
-        """Composer fields merge correctly."""
-        album = MetaAlbum(artist="album_artist")
-        track1 = MetaTrack(album, 1)
-        track2 = MetaTrack(
-            album,
-            1,
-            composer="Alex Harmony",
-        )
-
-        track1.merge(track2)
-
-        assert track1.composer == "Alex Harmony"
-
-    def test_composer_overwrite(self):
-        """Composer fields overwrite correctly when specified."""
-        album = MetaAlbum(artist="album_artist")
-        track1 = MetaTrack(
-            album,
-            1,
-            composer="Sam Rhythm",
-        )
-        track2 = MetaTrack(
-            album,
-            1,
-            composer="Taylor Beat",
-        )
-
-        track1.merge(track2, overwrite=True)
-
-        assert track1.composer == "Taylor Beat"
 
 
 class TestProperties:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -59,7 +59,7 @@ class TestWriteTags:
     """Tests `write_tags()`."""
 
     def test_write_tags(self, tmp_config):
-        """We can write track changes to the file."""
+        """Test writing and reading tags to a track."""
         tmp_config()
         track = track_factory(exists=True)
         artist = "4 Non Blondes"

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -67,6 +67,7 @@ class TestWriteTags:
         barcode = "1234"
         catalog_nums = {"1", "2"}
         composer = "Elephant Seal"
+        composer_sort = "Seal, Elephant"
         country = "US"
         date = datetime.date(1996, 10, 13)
         disc = 2
@@ -87,6 +88,7 @@ class TestWriteTags:
         track.album.date = date
         track.album.original_date = original_date
         track.composer = composer
+        track.composer_sort = composer_sort
         track.disc = disc
         track.album.disc_total = disc_total
         track.genres = genres
@@ -104,6 +106,7 @@ class TestWriteTags:
         assert new_track.artist == artist
         assert new_track.artists == artists
         assert new_track.composer == composer
+        assert new_track.composer_sort == composer_sort
         assert new_track.disc == disc
         assert new_track.genres == genres
         assert new_track.title == title

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -66,6 +66,7 @@ class TestWriteTags:
         artists = {"4 Non Blondes", "Me"}
         barcode = "1234"
         catalog_nums = {"1", "2"}
+        composer = "Elephant Seal"
         country = "US"
         date = datetime.date(1996, 10, 13)
         disc = 2
@@ -85,6 +86,7 @@ class TestWriteTags:
         track.album.country = country
         track.album.date = date
         track.album.original_date = original_date
+        track.composer = composer
         track.disc = disc
         track.album.disc_total = disc_total
         track.genres = genres
@@ -101,6 +103,7 @@ class TestWriteTags:
 
         assert new_track.artist == artist
         assert new_track.artists == artists
+        assert new_track.composer == composer
         assert new_track.disc == disc
         assert new_track.genres == genres
         assert new_track.title == title


### PR DESCRIPTION
- [x] I have read the contributing guide in the documentation.

### Description

This update introduces two new fields, `composer` and `composer_sort`, to tracks. 

It's my attempt at addressing the issue raised by discussion #282 around adding more track and album metadata. If we can add `composer` and `composer_sort` then we should be able to tag classical music better and I'll have a better understanding of how to add more metadata.

I assume I should also include/generate an Alembic migration, something like

```python
def upgrade():
    with op.batch_alter_table("track", schema=None) as batch_op:
        batch_op.add_column(sa.Column("composer", sa.String(), nullable=True))
        batch_op.add_column(sa.Column("composer_sort", sa.String(), nullable=True))


def downgrade():
    with op.batch_alter_table("track", schema=None) as batch_op:
        batch_op.drop_column("composer_sort")
        batch_op.drop_column("composer")
```
?


<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--295.org.readthedocs.build/en/295/

<!-- readthedocs-preview mrmoe end -->