### PR TITLE
feat(import): add `max_candidates` config option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -59,6 +59,21 @@ Move
 
     If ``true``, non-ascii characters will be converted to their ascii equivalents, e.g. ``café.mp3`` will become ``cafe.mp3``.
 
+Import
+------
+``max_candidates = 5``
+    Maximum number of candidate albums to display in the import prompt.
+
+    When running ``moe add``, this setting controls how many potential matches are shown when importing albums. Increasing this value allows you to see more options when multiple matches are found from metadata providers like MusicBrainz and Discogs.
+
+    .. code-block:: toml
+
+        [import]
+        max_candidates = 10  # Show up to 10 candidate albums
+
+    .. note::
+        This setting only affects the number of candidates displayed in the interactive prompt. To increase the number of candidates fetched from metadata providers, you may also need to adjust the search limits for individual plugins like ``musicbrainz.search_limit``.
+
 Path Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. note::

--- a/moe/moe_import/__init__.py
+++ b/moe/moe_import/__init__.py
@@ -2,6 +2,9 @@
 
 import sys
 
+import dynaconf
+import dynaconf.base
+
 import moe
 from moe import config
 


### PR DESCRIPTION
- [x] I have read the contributing guide in the documentation.

### Description

Introduced a new config option `max_candidates` to control the number of candidate albums displayed during the import process. Updated the import prompt to respect this setting and added validation for the configuration. Included docs and tests.

This option will be useful when using multiple multiple metadata plugins as currently `max_candidates` is hard coded to be 5. The docs mention a `search_limit` config option for the MusicBrainz plugin which is introduced by https://github.com/MoeMusic/moe_musicbrainz/pull/12.

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--302.org.readthedocs.build/en/302/

<!-- readthedocs-preview mrmoe end -->