### PR TITLE
fix(album): multi-disc albums not correctly setting the album's path

### DIFF
--- a/moe/library/album.py
+++ b/moe/library/album.py
@@ -393,7 +393,7 @@ class Album(LibItem, SABase, MetaAlbum):
         album: Optional[Album] = None
         for file_path in album_file_paths:
             try:
-                track = Track.from_file(file_path, album)
+                track = Track.from_file(file_path, album, album_path)
             except TrackError:
                 extra_paths.append(file_path)
             else:

--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -376,15 +376,24 @@ class Track(LibItem, SABase, MetaTrack):
         return 1
 
     @classmethod
-    def from_file(cls, track_path: Path, album: Optional[Album] = None) -> "Track":
+    def from_file(
+        cls,
+        track_path: Path,
+        album: Optional[Album] = None,
+        album_path: Optional[Path] = None,
+    ) -> "Track":
         """Alternate initializer that creates a Track from a track file.
 
         Will read any tags from the given path and save them to the Track.
 
         Args:
             track_path: Filesystem path of the track.
-            album: Corresponding album for the track. If not given, the album will be
-                created.
+            album: Corresponding album for the track. If ``None``, the album will be
+                created using the parent directory of ``track_path``, unless
+                ``album_path`` is also given.
+            album_path: When ``album`` is ``None``, this is the path of the created
+                album. If ``None`` it defaults to the parent directory of
+                ``track_path``.
 
         Returns:
             Track instance.
@@ -435,7 +444,7 @@ class Track(LibItem, SABase, MetaTrack):
 
         if not album:
             album = Album(
-                path=track_path.parent,
+                path=album_path or track_path.parent,
                 artist=album_artist,
                 title=album_title,
                 date=date,

--- a/tests/library/test_album.py
+++ b/tests/library/test_album.py
@@ -368,6 +368,7 @@ class TestFromDir:
         """We can add a multi-disc album."""
         tmp_config()
         album = album_factory(exists=True)
+        original_album_path = album.path
         track1 = album.tracks[0]
         track2 = album.tracks[1]
         track1.disc = 1
@@ -387,6 +388,7 @@ class TestFromDir:
 
         album = Album.from_dir(album.path)
 
+        assert album.path == original_album_path
         assert album.get_track(track1.track_num, track1.disc)
         assert album.get_track(track2.track_num, track2.disc)
 

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -220,6 +220,23 @@ class TestFromFile:
 
         Track.from_file(track.path).album.disc_total = 1
 
+    def test_init_album_defaults(self, tmp_config):
+        """If an album is not given, we will create it with the track's parent path."""
+        tmp_config()
+        track = track_factory(exists=True)
+
+        new_track = Track.from_file(track.path)
+        assert new_track.album.path == new_track.path.parent
+
+    def test_init_album_with_album_path(self, tmp_config):
+        """If an album is not given, we will create it with a specified album_path."""
+        tmp_config()
+        track = track_factory(exists=True)
+        album_path = track.path.parent.parent
+
+        new_track = Track.from_file(track.path, None, album_path)
+        assert new_track.album.path == album_path
+
 
 class TestEquality:
     """Test equality of tracks."""


### PR DESCRIPTION
When reading a multi-disc album from the filesystem and creating its corresponding `album` object, the album's path is now correctly set. This adds a new `album_path` argument to `Track.from_file` that allows the album's path to specifically set rather than defaulting to the track's parent directory.

Fixes #300


<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--304.org.readthedocs.build/en/304/

<!-- readthedocs-preview mrmoe end -->