### PR TITLE
Plugin uninstalled warning

### DIFF
--- a/moe/config.py
+++ b/moe/config.py
@@ -421,6 +421,13 @@ class Config:
         self.pm.hook.add_hooks(pm=self.pm)
 
         log.debug(f"Registered plugins. [plugins={self.pm.list_name_plugin()}]")
+        # check if all enabled plugins were loaded
+        for plugin in self.enabled_plugins:
+            if not self.pm.has_plugin(plugin):
+                log.warning(
+                    f"Plugin {plugin!r} is enabled in the configuration but could not "
+                    "be loaded. Is it installed?"
+                )
 
     def _register_local_plugins(
         self, enabled_plugins: set[str], plugin_dir: Path, pkg_name: str = ""

--- a/tests/add/test_add_cli.py
+++ b/tests/add/test_add_cli.py
@@ -190,7 +190,7 @@ class TestPluginRegistration:
 
         assert not config.pm.has_plugin("add_cli")
 
-    def test_cli(self, caplog, tmp_config):
+    def test_cli(self, tmp_config):
         """Enable the add cli plugin if the `cli` plugin is enabled."""
         config = tmp_config(settings='default_plugins = ["add", "cli"]')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests configuration."""
 
+import logging
 import shutil
 from pathlib import Path
 from unittest.mock import patch
@@ -99,6 +100,20 @@ class TestPlugins:
         tmp_config(settings="enable_plugins = ['my_list']", config_dir=config_dir)
 
         assert config.CONFIG.pm.has_plugin("my_list")
+
+    def test_warn_uninstalled_plugin(self, tmp_config, caplog):
+        """Warn the user if an enabled plugin cannot be loaded."""
+        with caplog.at_level(logging.WARNING):
+            tmp_config(
+                settings="""enable_plugins = ["non_existent"]
+            """
+            )
+            assert (
+                "Plugin 'non_existent' is enabled in the configuration but could not be"
+                " loaded. Is it installed?" in caplog.text
+            )
+
+        assert not config.CONFIG.pm.has_plugin("non_existent")
 
 
 class ConfigPlugin:


### PR DESCRIPTION
Log a warning if the user enabled a plugin in their config, but it couldn't be loaded. Also refactors a bit of the plugin loading logic.

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--307.org.readthedocs.build/en/307/

<!-- readthedocs-preview mrmoe end -->