### PR TITLE
feat(track): add duration field to `Track` and match on duration

### DIFF
--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -105,6 +105,8 @@ def read_custom_tags(
     track_fields["disc"] = audio_file.disc
     if audio_file.genres is not None:
         track_fields["genres"] = set(audio_file.genres)
+    if audio_file.length:
+        track_fields["duration"] = audio_file.length
     track_fields["title"] = audio_file.title
     track_fields["track_num"] = audio_file.track
 
@@ -126,6 +128,7 @@ class MetaTrack(MetaLibItem):
         artists (Optional[set[str]]): Set of all artists.
         custom (dict[str, Any]): Dictionary of custom fields.
         disc (Optional[int]): Disc number the track is on.
+        duration (Optional[float]): Track duration in seconds.
         genres (Optional[set[str]]): Set of all genres.
         title (Optional[str])
         track_num (Optional[int])
@@ -138,6 +141,7 @@ class MetaTrack(MetaLibItem):
         artist: Optional[str] = None,
         artists: Optional[set[str]] = None,
         disc: int = 1,
+        duration: Optional[float] = None,
         genres: Optional[set[str]] = None,
         title: Optional[str] = None,
         **kwargs,
@@ -152,6 +156,7 @@ class MetaTrack(MetaLibItem):
         self.artist = artist or self.album.artist
         self.artists = artists
         self.disc = disc
+        self.duration = duration
         self.genres = genres
         self.title = title
 
@@ -185,6 +190,7 @@ class MetaTrack(MetaLibItem):
             "artist",
             "artists",
             "disc",
+            "duration",
             "genres",
             "title",
             "track_num",
@@ -276,6 +282,7 @@ class Track(LibItem, SABase, MetaTrack):
         artists (Optional[set[str]]): Set of all artists.
         custom (dict[str, Any]): Dictionary of custom fields.
         disc (int): Disc number the track is on.
+        duration (Optional[float]): Track duration in seconds.
         genres (Optional[set[str]]): Set of all genres.
         path (Path): Filesystem path of the track file.
         title (str)
@@ -293,6 +300,7 @@ class Track(LibItem, SABase, MetaTrack):
         MutableSet.as_mutable(SetType()), nullable=True
     )
     disc: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    duration: Mapped[Optional[float]] = mapped_column(nullable=True)
     genres: Mapped[Optional[set[str]]] = mapped_column(
         MutableSet.as_mutable(SetType()), nullable=True
     )
@@ -316,6 +324,7 @@ class Track(LibItem, SABase, MetaTrack):
         artist: Optional[str] = None,
         artists: Optional[set[str]] = None,
         disc: Optional[int] = None,
+        duration: Optional[float] = None,
         genres: Optional[set[str]] = None,
         **kwargs,
     ):
@@ -330,6 +339,7 @@ class Track(LibItem, SABase, MetaTrack):
             artists: Set of all artists.
             disc: Disc the track belongs to. If not given, will try to guess the disc
                 based on the ``path`` of the track.
+            duration: Duration of the track.
             genres (Optional[set[str]]): Set of all genres.
             **kwargs: Any custom fields to assign to the track.
         """
@@ -341,6 +351,7 @@ class Track(LibItem, SABase, MetaTrack):
         self.artist = artist or self.album.artist
         self.artists = artists
         self.disc = disc or self._guess_disc()
+        self.duration = duration
         self.genres = genres
         self.title = title
         self.track_num = track_num

--- a/moe/moe_alembic/versions/421189d03b1d_new_field_duration.py
+++ b/moe/moe_alembic/versions/421189d03b1d_new_field_duration.py
@@ -1,0 +1,26 @@
+"""new field: duration.
+
+Revision ID: 421189d03b1d
+Revises: ab5db9861d30
+Create Date: 2025-06-15 08:24:02.305917
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "421189d03b1d"
+down_revision = "ab5db9861d30"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("duration", sa.Float(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("track", schema=None) as batch_op:
+        batch_op.drop_column("duration")

--- a/moe/moe_import/import_cli.py
+++ b/moe/moe_import/import_cli.py
@@ -297,6 +297,7 @@ def _fmt_tracks(new_album: Album, candidate: CandidateAlbum) -> Table:
     track_table.add_column("#")
     track_table.add_column("Artist")
     track_table.add_column("Title")
+    track_table.add_column("Duration")
 
     matches = get_matching_tracks(new_album, candidate.album)
     matches.sort(
@@ -316,6 +317,7 @@ def _fmt_tracks(new_album: Album, candidate: CandidateAlbum) -> Table:
                 _fmt_field_changes(old_track, new_track, "track_num"),
                 _fmt_field_changes(old_track, new_track, "artist"),
                 _fmt_field_changes(old_track, new_track, "title"),
+                _fmt_duration_changes(old_track, new_track),
             )
         elif old_track and not new_track:
             unmatched_tracks.append(old_track)
@@ -331,6 +333,7 @@ def _fmt_tracks(new_album: Album, candidate: CandidateAlbum) -> Table:
             str(missing_track.track_num),
             missing_track.artist,
             missing_track.title,
+            _fmt_duration(missing_track),
         )
     for unmatched_track in sorted(unmatched_tracks):
         track_table.add_row(
@@ -339,6 +342,7 @@ def _fmt_tracks(new_album: Album, candidate: CandidateAlbum) -> Table:
             str(unmatched_track.track_num),
             unmatched_track.artist,
             unmatched_track.title,
+            _fmt_duration(unmatched_track),
         )
 
     return track_table
@@ -387,3 +391,40 @@ def _fmt_field_changes(
         return Text(str(old_field))
     else:
         return None
+
+
+def _fmt_duration_changes(old_track: MetaTrack, new_track: MetaTrack) -> Text:
+    """Formats the duration changes between two tracks."""
+    old_duration = _get_track_duration_str(old_track)
+    new_duration = _get_track_duration_str(new_track)
+
+    if old_duration and new_duration:
+        if old_duration == new_duration:
+            return Text(old_duration)
+        else:
+            return (
+                Text(old_duration)
+                .append(Text(" -> ", style="yellow"))
+                .append(Text(new_duration))
+            )
+    elif old_duration:
+        return Text(old_duration, style="red strike")
+    elif new_duration:
+        return Text(new_duration, style="green")
+    else:
+        return Text("N/A")
+
+
+def _fmt_duration(track: MetaTrack) -> Text:
+    """Formats the duration of a track."""
+    duration_str = _get_track_duration_str(track)
+    return Text(duration_str if duration_str else "N/A")
+
+
+def _get_track_duration_str(track: MetaTrack) -> Optional[str]:
+    """Get formatted duration string for a track (MM:SS format)."""
+    if hasattr(track, "duration") and track.duration:
+        minutes = int(track.duration // 60)
+        seconds = int(track.duration % 60)
+        return f"{minutes}:{seconds:02d}"
+    return None

--- a/moe/util/core/match.py
+++ b/moe/util/core/match.py
@@ -31,6 +31,7 @@ MATCH_ALBUM_FIELD_WEIGHTS = {
 
 MATCH_TRACK_FIELD_WEIGHTS = {
     "disc": 0.3,
+    "duration": 0.5,
     "title": 0.7,
     "track_num": 0.9,
 }  # how much to weigh matches of various fields
@@ -69,6 +70,21 @@ def get_match_value(
         else:
             if isinstance(value_a, str):
                 penalty = 1 - difflib.SequenceMatcher(None, value_a, value_b).ratio()
+            elif (
+                field == "duration"
+                and isinstance(value_a, (int, float))
+                and isinstance(value_b, (int, float))
+            ):
+                max_duration = max(value_a, value_b)
+                tolerance = max_duration * 0.025  # 2.5% of max duration
+
+                diff = abs(value_a - value_b)
+                if diff <= tolerance:
+                    penalty = 0
+                else:
+                    # Gradually increase penalty beyond tolerance
+                    # with max penalty at 3x tolerance.
+                    penalty = min(1.0, diff / (3 * tolerance))
             else:
                 if value_a != value_b:
                     penalty = 1

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -450,3 +450,29 @@ class TestLessThan:
         track2 = MetaTrack(album=MetaAlbum(title="a"), track_num=1, disc=2)
 
         assert track1 < track2
+
+
+class TestDurationField:
+    """Test duration field functionality."""
+
+    def test_duration_init_and_access(self):
+        """Duration should be settable and accessible on tracks."""
+        track = track_factory(duration=182.5)
+        album = MetaAlbum(artist="Test Artist")
+        meta_track = MetaTrack(album, 1, duration=245.0)
+
+        assert track.duration == 182.5
+        assert meta_track.duration == 245.0
+
+    def test_duration_in_fields(self):
+        """Duration should be included in track fields."""
+        track = track_factory()
+        assert "duration" in track.fields
+
+    def test_duration_merge(self):
+        """Duration should be merged between tracks."""
+        track1 = track_factory(duration=None)
+        track2 = track_factory(duration=180.0, dup_track=track1)
+
+        track1.merge(track2)
+        assert track1.duration == 180.0

--- a/tests/util/core/test_match.py
+++ b/tests/util/core/test_match.py
@@ -153,3 +153,31 @@ class TestMatchValue:
         assert track1.track_num != track2.track_num
 
         assert get_match_value(track1, track2) < 1
+
+
+class TestDurationMatching:
+    """Test duration matching logic."""
+
+    def test_within_tolerance_duration_match(self):
+        """Tracks within 2.5% tolerance should match without penalty."""
+        track1 = track_factory(duration=180.0)
+        track2 = track_factory(dup_track=track1)
+        track2.duration = 184.0
+
+        assert get_match_value(track1, track2) > 0.9
+
+    def test_outside_tolerance_duration_match(self):
+        """Tracks outside 2.5% tolerance should have reduced match value."""
+        track1 = track_factory(duration=180.0)
+        track2 = track_factory(dup_track=track1)
+        track2.duration = 195.0
+
+        assert get_match_value(track1, track2) < 0.9
+
+    def test_missing_duration_handling(self):
+        """Track with missing duration should still match on other fields."""
+        track1 = track_factory(duration=180.0)
+        track2 = track_factory(dup_track=track1)
+        track2.duration = None
+
+        assert 0.7 < get_match_value(track1, track2) < 0.9


### PR DESCRIPTION
- [ ] I have read the contributing guide in the documentation.

### Description

I think it would be very useful to be able to match on track duration in addition to track title. Testing on my fork, this actually improved matches for me and there were albums where half the tracks were unmatched/missing that now fully match. To be fair, this is mostly for albums where the file track titles are in one language and the candidate track titles are in another. But with track duration matching they match perfectly.

So this PR introduces a new `duration` field to `Track` and `MetaTrack`. I updated `read_custom_tags` to populate this field from audio files, updated the import CLI to display track duration and added formatting functions for duration changes, and updated matching logic to include duration with a tolerance-based penalty system. Also added some tests, but not too sure of the best way to test the updated import CLI as I mostly added a private function `_fmt_duration_changes`.

### Additional information

Opening this as a draft PR to get your thoughts @jtpavlock on whether this is the correct approach. Since #295 also introduces Alembic migrations, it may have to be merged first then this PR would need to recreate the migration script on top of the composer migrations.

Will open an accompanying PR for the MusicBrains plugin.