### PR TITLE
ci: new ci check to block merging fixup commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,10 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  fixup-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Block fixup commit merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Now that we're using fixup commits, I wanted something to prevent forgetting to autosquash before merging into main.