### PR TITLE
feat(track): match on track duration

### DIFF
--- a/moe/library/track.py
+++ b/moe/library/track.py
@@ -141,6 +141,7 @@ class MetaTrack(MetaLibItem):  # noqa: PLW1641 MetaTracks are unhashable
         composer_sort (str | None): Composer sort field.
         custom (dict[str, Any]): Dictionary of custom fields.
         disc (int | None): Disc number the track is on.
+        duration (float | None): Duration of the track in seconds.
         genres (set[str] | None): Set of all genres.
         title (str | None)
         track_num (int | None)
@@ -155,6 +156,7 @@ class MetaTrack(MetaLibItem):  # noqa: PLW1641 MetaTracks are unhashable
         composer: str | None = None,
         composer_sort: str | None = None,
         disc: int = 1,
+        duration: float | None = None,
         genres: set[str] | None = None,
         title: str | None = None,
         **kwargs: object,
@@ -171,6 +173,7 @@ class MetaTrack(MetaLibItem):  # noqa: PLW1641 MetaTracks are unhashable
         self.composer = composer
         self.composer_sort = composer_sort
         self.disc = disc
+        self.duration = duration
         self.genres = genres
         self.title = title
 
@@ -206,6 +209,7 @@ class MetaTrack(MetaLibItem):  # noqa: PLW1641 MetaTracks are unhashable
             "composer",
             "composer_sort",
             "disc",
+            "duration",
             "genres",
             "title",
             "track_num",
@@ -515,7 +519,7 @@ class Track(LibItem, SABase, MetaTrack):
     @property
     def fields(self) -> set[str]:
         """Returns any editable, track-specific fields."""
-        return super().fields.union({"path"})
+        return super().fields.union({"path"}) - {"duration"}
 
     @property
     def sample_rate(self) -> int:

--- a/tests/util/core/test_match.py
+++ b/tests/util/core/test_match.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from moe.util.core import get_match_value, get_matching_tracks
+from moe.util.core.match import MatchType, get_field_match_penalty
 from tests.conftest import album_factory, track_factory
 
 
@@ -11,7 +14,7 @@ class TestGetMatchingTracks:
 
     def test_full_match(self):
         """All tracks have matches."""
-        album_a = album_factory()
+        album_a = album_factory(exists=True)
         album_b = album_factory(dup_album=album_a)
 
         track_matches = get_matching_tracks(album_a, album_b)
@@ -31,7 +34,7 @@ class TestGetMatchingTracks:
 
         Any non-matched tracks should be paired with ``None``.
         """
-        album_a = album_factory()
+        album_a = album_factory(exists=True)
         album_b = album_factory(dup_album=album_a)
 
         track_matches = get_matching_tracks(album_a, album_b, match_threshold=1.1)
@@ -47,8 +50,8 @@ class TestGetMatchingTracks:
 
     def test_high_threshold(self):
         """A zero threshold should always return a match."""
-        track1 = track_factory(track_num=1)
-        track2 = track_factory(track_num=2)
+        track1 = track_factory(track_num=1, exists=True)
+        track2 = track_factory(track_num=2, exists=True)
         assert track1.track_num != track2.track_num
 
         track_matches = get_matching_tracks(
@@ -62,9 +65,9 @@ class TestGetMatchingTracks:
 
     def test_a_longer_than_b(self):
         """Any unmatched tracks should be paired with ``None``."""
-        album_a = album_factory()
-        album_b = album_factory()
-        track = track_factory(album=album_a)
+        album_a = album_factory(exists=True)
+        album_b = album_factory(exists=True)
+        track = track_factory(album=album_a, exists=True)
 
         track_matches = get_matching_tracks(album_a, album_b)
 
@@ -72,9 +75,9 @@ class TestGetMatchingTracks:
 
     def test_b_longer_than_a(self):
         """Any unmatched tracks should be paired with ``None``."""
-        album_a = album_factory()
-        album_b = album_factory()
-        track = track_factory(album=album_b)
+        album_a = album_factory(exists=True)
+        album_b = album_factory(exists=True)
+        track = track_factory(album=album_b, exists=True)
 
         track_matches = get_matching_tracks(album_a, album_b)
 
@@ -82,12 +85,12 @@ class TestGetMatchingTracks:
 
     def test_multiple_same_match(self):
         """Any track should not have more than one match."""
-        track1 = track_factory(track_num=1)
-        track2 = track_factory(track_num=2)
+        track1 = track_factory(track_num=1, exists=True)
+        track2 = track_factory(track_num=2, exists=True)
         track1.album = track2.album
 
-        track3 = track_factory(track_num=3)
-        track4 = track_factory(track_num=4)
+        track3 = track_factory(track_num=3, exists=True)
+        track4 = track_factory(track_num=4, exists=True)
         track3.album = track4.album
 
         track3.title = "not a match"
@@ -139,15 +142,15 @@ class TestMatchValue:
 
     def test_same_track(self):
         """Tracks with the same values for all used fields should be a perfect match."""
-        track1 = track_factory()
+        track1 = track_factory(exists=True)
         track2 = track_factory(dup_track=track1)
 
         assert get_match_value(track1, track2) > self.HIGH_MATCH_THRESHOLD
 
     def test_diff_track(self):
         """Tracks with different values for each field should not match."""
-        track1 = track_factory()
-        track2 = track_factory()
+        track1 = track_factory(exists=True)
+        track2 = track_factory(exists=True)
         track1.title = "a"
         track2.title = "b"
         track1.disc = 2
@@ -156,3 +159,81 @@ class TestMatchValue:
         assert track1.track_num != track2.track_num
 
         assert get_match_value(track1, track2) < self.LOW_MATCH_THRESHOLD
+
+
+class TestGetFieldMatchPenalty:
+    """Test ``get_field_match_penalty()``."""
+
+    @pytest.mark.parametrize(
+        ("str_a", "str_b", "assertion"),
+        [
+            ("test", "test", lambda p: p == 0.0),  # same has 0 penalty
+            ("test", "xyz", lambda p: p == 1.0),  # entirely dissimilar as full penalty
+            ("test", "tst", lambda p: 0.0 < p < 1.0),  # similar is in between
+        ],
+    )
+    def test_string_match_type(self, str_a, str_b, assertion):
+        """Identical strings should have zero penalty."""
+        penalty = get_field_match_penalty(str_a, str_b, MatchType.STRING)
+
+        assert assertion(penalty)
+
+    @pytest.mark.parametrize(
+        ("bool_a", "bool_b", "penalty"),
+        [
+            (7, 7, 0.0),  # no penalty for same value
+            (7, 6, 1.0),  # full penalty for different value
+        ],
+    )
+    def test_bool_match_type(self, bool_a, bool_b, penalty):
+        """MatchType.BOOL should return 0 if the two values are equal."""
+        assert get_field_match_penalty(bool_a, bool_b, MatchType.BOOL) == penalty
+
+    @pytest.mark.parametrize(
+        ("duration_b_multiplier", "assertion"),
+        [
+            (1.0, lambda p: p == 0.0),  # identical
+            (1.02, lambda p: p == 0.0),  # within tolerance
+            (1.06, lambda p: 0.0 < p < 1.0),  # moderate mismatch
+            (1.15, lambda p: p == 1.0),  # large mismatch
+        ],
+    )
+    def test_duration_match_type(self, duration_b_multiplier, assertion):
+        """Tests duration penalty scenarios."""
+        base_duration = 180.0
+        duration_b = base_duration * duration_b_multiplier
+
+        penalty = get_field_match_penalty(base_duration, duration_b, MatchType.DURATION)
+
+        assert assertion(penalty)
+
+    @pytest.mark.parametrize(
+        "match_type", [MatchType.STRING, MatchType.BOOL, MatchType.DURATION]
+    )
+    def test_both_values_missing_penalty(self, match_type):
+        """A 0.2 penalty is returned when both values are missing."""
+        both_missing_penalty = 0.2
+
+        assert get_field_match_penalty(None, None, match_type) == both_missing_penalty
+
+    @pytest.mark.parametrize(
+        ("value_a", "value_b", "match_type"),
+        [
+            ("test", None, MatchType.STRING),
+            (None, "test", MatchType.STRING),
+            ("", "test", MatchType.STRING),  # empty string counts as missing
+            ("test", "", MatchType.STRING),  # empty string counts as missing
+            (1, None, MatchType.BOOL),
+            (1, 0, MatchType.BOOL),  # falsey values are considered missing
+            (None, 1, MatchType.BOOL),
+            (0.0, 1.0, MatchType.DURATION),  # falsey values are considered missing
+            (1.0, None, MatchType.DURATION),
+        ],
+    )
+    def test_one_value_missing_penalty(self, value_a, value_b, match_type):
+        """A 0.1 penalty is returned when one value is missing."""
+        one_missing_penalty = 0.1
+
+        assert (
+            get_field_match_penalty(value_a, value_b, match_type) == one_missing_penalty
+        )


### PR DESCRIPTION
- [x] I have read the contributing guide in the documentation.

### Description

Added a `duration` property to the `MetaTrack` class. `get_match_value` will now consider track duration using a tolerance-based penalty system where a duration mismatch of 2.5% or less is not penalized, and the penalty increases linearly from 0 at 2.5% to 1 at 10% mismatch. Let me know what you think of this heuristic.

Also updated the tests. I had to pass `exists=True` to a lot of track and album factories (and enable the write plugin in some tests) as the import process and track matching now calls `Track.duration` which expects a file to exist from which to pull out a duration. There was only one test where I had to resort to patching.

Once this PR is merged, I'll open a PR for moe_musicbrainz to populate `MetaTrack.duration` and we should be up and running!

This PR is a result of discussions had in #313.

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--317.org.readthedocs.build/en/317/

<!-- readthedocs-preview mrmoe end -->