### PR TITLE
ci: make era001 a file-ignore for conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# sys.path.insert(0, os.path.abspath('.'))  # noqa: ERA001
+# sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -47,7 +47,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "global.rst"]
 rst_prolog = Path("global.rst").read_text()
 
 # include type hints in function description
-# autodoc_typehints = "description" # noqa: ERA001
+# autodoc_typehints = "description"
 
 # don't include module names in autodoc functions
 add_module_names = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ ignore = [
     "SLF001", # alembic scripts can access private members
 ]
 "docs/conf.py" = [
+    "ERA001", # conf.py includes commented config options
     "INP001", # docs directory isn't a python package
 ]
 "tests/*" = [


### PR DESCRIPTION
`conf.py` is a configuration file and it's common to want to comment unused configuration values.

making this change here because I'm going to do the same for other repositories

ERA001 flags any commented out code

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--318.org.readthedocs.build/en/318/

<!-- readthedocs-preview mrmoe end -->