### PR TITLE
refactor(gitignore): ignore .envrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.envrc
 
 # mypy
 .mypy_cache/


### PR DESCRIPTION
Ignore .envrc files used by [direnv](https://direnv.net/) which I recently started using and liking in my local environment

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--322.org.readthedocs.build/en/322/

<!-- readthedocs-preview mrmoe end -->