### PR TITLE
fix: sanitize unicode equivalent colon and forward slashes in paths

### DIFF
--- a/moe/move/move_core.py
+++ b/moe/move/move_core.py
@@ -285,7 +285,7 @@ def _sanitize_path_part(path_part: str) -> str:
     """
     path_replace_chars = {
         r"^\.": "_",  # leading '.' (hidden files on Unix)
-        r'[<>:"\?\*\|\\/]': "_",  # <, >, : , ", ?, *, |, \, / (Windows reserved chars)
+        r'[<>:"\?\*\|\\/∶／⁄]': "_",  # <, >, :, ", ?, *, |, \, / (Windows reserved chars + unicode variants) # noqa: RUF001, E501
         r"\.$": "_",  # trailing '.' (Windows restriction)
         r"\s+$": "",  # trailing whitespace (Windows restriction)
     }

--- a/tests/move/test_move_core.py
+++ b/tests/move/test_move_core.py
@@ -103,8 +103,8 @@ class TestFmtItemPath:
         )
         tracks = []
         replacements = []
-        tracks.append(track_factory(title='/ reserved <, >, :, ", ?, *, |, /'))
-        replacements.append("_ reserved _, _, _, _, _, _, _, _")
+        tracks.append(track_factory(title='/ reserved <, >, :, ", ?, *, |, /, ⁄, ∶'))  # noqa: RUF001
+        replacements.append("_ reserved _, _, _, _, _, _, _, _, _, _")
         tracks.append(track_factory(title=".leading dot"))
         replacements.append("_leading dot")
         tracks.append(track_factory(title="trailing dot."))


### PR DESCRIPTION
<!-- Thank you for contributing to Moe! Please ensure you've read the contributing guide in the documentation and check the below box to acknowledge you have done so.-->
- [ ] I have read the contributing guide in the documentation.

<!-- Description of the changes this pull request makes. -->
### Description

Fixes #325 by including the unicode variants of the colon and forward slash in the path sanitization

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--326.org.readthedocs.build/en/326/

<!-- readthedocs-preview mrmoe end -->