### PR TITLE
Fix cli docs

### DIFF
--- a/docs/developers/api/api.rst
+++ b/docs/developers/api/api.rst
@@ -45,7 +45,7 @@ API Definitions
 ===============
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 3
 
    hooks
    cli

--- a/docs/developers/api/cli.rst
+++ b/docs/developers/api/cli.rst
@@ -7,6 +7,13 @@ CLI
    :members:
    :show-inheritance:
 
+Import
+======
+``moe.moe_import``
+
+.. automodule:: moe.moe_import.import_cli
+   :members:
+
 Util
 ====
 ``moe.util.cli``

--- a/docs/developers/api/core.rst
+++ b/docs/developers/api/core.rst
@@ -38,7 +38,7 @@ Import
 ======
 ``moe.moe_import``
 
-.. automodule:: moe.moe_import
+.. automodule:: moe.moe_import.import_core
    :members:
    :exclude-members: match_value_pct
 


### PR DESCRIPTION
import cli api documentation was incorrectly listed under the "core" api documentation. Also limits the api TOC tree to reduce unncessary clutter.

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--333.org.readthedocs.build/en/333/

<!-- readthedocs-preview mrmoe end -->