### PR TITLE
N818 Exception Naming

### DIFF
--- a/moe/add/add_cli.py
+++ b/moe/add/add_cli.py
@@ -23,7 +23,7 @@ log = logging.getLogger("moe.cli.add")
 __all__: list[str] = []
 
 
-class SkipAdd(Exception):  # noqa: N818 breaking change
+class SkipAddError(Exception):
     """Used to skip adding a single item."""
 
 
@@ -60,7 +60,7 @@ def _skip_import(
     new_album: Album,  # noqa: ARG001
 ) -> None:
     """Skip adding/importing the current item."""
-    raise SkipAdd
+    raise SkipAddError
 
 
 def _parse_args(session: Session, args: argparse.Namespace) -> None:
@@ -93,7 +93,7 @@ def _parse_args(session: Session, args: argparse.Namespace) -> None:
         except (AddError, AlbumError):  # noqa: PERF203
             log.exception("Error adding item.")
             error_count += 1
-        except SkipAdd:
+        except SkipAddError:
             log.debug(f"Skipped adding item. [{path=}]")
 
     if error_count:
@@ -112,7 +112,7 @@ def _add_path(session: Session, path: Path, album: Album | None) -> None:
     Raises:
         AddError: Path not found or other issue adding the item to the library.
         AlbumError: Could not create an album from the given directory.
-        SkipAdd: External program or user elected to skip adding the item.
+        SkipAddError: External program or user elected to skip adding the item.
     """
     if path.is_file():
         try:

--- a/moe/moe_import/import_cli.py
+++ b/moe/moe_import/import_cli.py
@@ -31,7 +31,7 @@ log = logging.getLogger("moe.cli.import")
 __all__ = ["candidate_prompt", "import_prompt"]
 
 
-class AbortImport(Exception):  # noqa: N818 breaking change
+class AbortImportError(Exception):
     """Used to abort the import process."""
 
 
@@ -129,7 +129,7 @@ def process_candidates(new_album: Album, candidates: list[CandidateAlbum]) -> No
         max_candidates = config.CONFIG.settings.get("import.max_candidates")
         try:
             candidate_prompt(new_album, candidates[:max_candidates])
-        except AbortImport as err:
+        except AbortImportError as err:
             log.debug(err)
             raise SystemExit(0) from err
 
@@ -142,7 +142,7 @@ def candidate_prompt(new_album: Album, candidates: list[CandidateAlbum]) -> None
         candidates: List of candidates to choose from.
 
     Raises:
-        AbortImport: Import prompt was aborted by the user.
+        AbortImportError: Import prompt was aborted by the user.
     """
     prompt_choices: list[PromptChoice] = []
 
@@ -204,7 +204,7 @@ def import_prompt(
             against ``old_album``.
 
     Raises:
-        AbortImport: Import prompt was aborted by the user.
+        AbortImportError: Import prompt was aborted by the user.
     """
     log.debug(f"Running import prompt. [{new_album=}, {candidate=}]")
 
@@ -249,7 +249,7 @@ def _abort_changes(
 ) -> None:
     """Aborts the album changes."""
     err_msg = "Import prompt aborted; no changes made."
-    raise AbortImport(err_msg)
+    raise AbortImportError(err_msg)
 
 
 def _fmt_import_updates(new_album: Album, candidate: CandidateAlbum) -> Panel:

--- a/tests/add/test_add_cli.py
+++ b/tests/add/test_add_cli.py
@@ -61,7 +61,7 @@ class TestAddImportPromptChoice:
         config.CONFIG.pm.hook.add_import_prompt_choice(prompt_choices=prompt_choices)
         skip_choice = next(c for c in prompt_choices if c.shortcut_key == "s")
 
-        with pytest.raises(add_cli.SkipAdd):
+        with pytest.raises(add_cli.SkipAddError):
             skip_choice.func(album, candidate)
 
 

--- a/tests/import/test_import_cli.py
+++ b/tests/import/test_import_cli.py
@@ -121,7 +121,7 @@ class TestProcessCandidates:
         with (
             patch(
                 "moe.moe_import.import_cli.candidate_prompt",
-                side_effect=moe_import.import_cli.AbortImport,
+                side_effect=moe_import.import_cli.AbortImportError,
                 autospec=True,
             ),
             pytest.raises(SystemExit) as error,
@@ -365,7 +365,7 @@ class TestAddImportPromptChoice:
             assert extra.path
 
     def test_abort(self):
-        """The `abort` prompt choice should raise an AbortImport error."""
+        """The `abort` prompt choice should raise an AbortImportError."""
         album = album_factory()
         candidate = CandidateAlbum(
             album=album_factory(),
@@ -383,7 +383,7 @@ class TestAddImportPromptChoice:
                 return_value=abort_choice,
                 autospec=True,
             ),
-            pytest.raises(moe_import.import_cli.AbortImport),
+            pytest.raises(moe_import.import_cli.AbortImportError),
         ):
             moe_import.import_cli.import_prompt(album, candidate)
 


### PR DESCRIPTION
Addresses [N818 linting code](https://docs.astral.sh/ruff/rules/error-suffix-on-exception-name/). 

I'm not considering this a breaking change because these errors were never exposed to the API documentation and are only intended for internal control flow purposes.

<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--334.org.readthedocs.build/en/334/

<!-- readthedocs-preview mrmoe end -->