### PR TITLE
refactor(config): Config(None) now defaults to user home directory

### DIFF
--- a/moe/config.py
+++ b/moe/config.py
@@ -240,7 +240,7 @@ class Config:
 
     def __init__(
         self,
-        config_dir: Path = Path.home() / ".config" / "moe",  # noqa: B008 breaking change required
+        config_dir: Path | None = None,
         settings_filename: str = "config.toml",
         extra_plugins: list[ExtraPlugin] | None = None,
         engine: sqlalchemy.engine.base.Engine | None = None,
@@ -251,7 +251,8 @@ class Config:
         Args:
             config_dir: Filesystem path of the configuration directory where the
                 settings and database files will reside. The environment variable
-                ``MOE_CONFIG_DIR`` has precedence in setting this.
+                ``MOE_CONFIG_DIR`` has precedence in setting this. If ``None`` given,
+                the config directory defaults to ``~/.config/moe``.
             extra_plugins: Any extra plugins that should be enabled in addition to those
                 specified in the configuration.
             settings_filename: Name of the configuration settings file.
@@ -265,7 +266,7 @@ class Config:
         try:
             self.config_dir = Path(os.environ["MOE_CONFIG_DIR"])
         except KeyError:
-            self.config_dir = config_dir
+            self.config_dir = config_dir or Path.home() / ".config" / "moe"
 
         self.config_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests configuration."""
 
 import logging
+import os
 import shutil
 from pathlib import Path
 from unittest.mock import patch
@@ -21,6 +22,16 @@ class TestInit:
         config = Config(tmp_path / "doesn't exist", init_db=False)
 
         assert config.config_dir.is_dir()
+
+    def test_default_config_dir(self):
+        """The default config directory should be `~/.config/moe`."""
+        # ensure the "MOE_CONFIG_DIR" envvar is not set as it will override the default
+        environ_copy = os.environ.copy()
+        environ_copy.pop("MOE_CONFIG_DIR", None)
+        with patch.dict("os.environ", environ_copy, clear=True):
+            config = Config(None, init_db=False)
+
+            assert config.config_dir == Path.home() / ".config" / "moe"
 
     def test_config_file_dne(self, tmp_path):
         """Should create an empty config file if it doesn't exist."""


### PR DESCRIPTION
<!-- Description of the changes this pull request makes. -->
### Description
This change moves the default config directory logic to within __init__ rather than in the method signature, addressing the B008 lint error.

This change also forces us to accept "None" as a value for the config directory which would have previously been invalid. Because we also still accept any "Path" object, this change is backwards compatible and not a breaking change.

<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information
[B008 linting error docs](https://docs.astral.sh/ruff/rules/function-call-in-default-argument/)

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--338.org.readthedocs.build/en/338/

<!-- readthedocs-preview mrmoe end -->