### PR TITLE
refactor(query)!: change query_type arg to an enum

### DIFF
--- a/moe/add/add_cli.py
+++ b/moe/add/add_cli.py
@@ -10,6 +10,7 @@ import moe
 import moe.add
 from moe.add.add_core import AddError
 from moe.library import Album, AlbumError, Extra, Track, TrackError
+from moe.query import QueryType
 from moe.util.cli import PromptChoice
 from moe.util.cli.query import cli_query
 
@@ -79,7 +80,9 @@ def _parse_args(session: Session, args: argparse.Namespace) -> None:
 
     album: Album | None = None
     if args.album_query:
-        albums = cast("list[Album]", cli_query(session, args.album_query, "album"))
+        albums = cast(
+            "list[Album]", cli_query(session, args.album_query, QueryType.ALBUM)
+        )
 
         if len(albums) > 1:
             log.error("Query returned more than one album.")

--- a/moe/cli.py
+++ b/moe/cli.py
@@ -70,7 +70,7 @@ class Hooks:
                     parents=[moe.cli.query_parser],
                 )
 
-            Then, you can call ``query.query(args.query, query_type=args.query_type)``
+            Then, you can call ``query.query(args.query, args.query_type)``
             to get a list of items matching the query from the library.
 
         See Also:

--- a/moe/duplicate/dup_core.py
+++ b/moe/duplicate/dup_core.py
@@ -10,7 +10,7 @@ import sqlalchemy
 import moe
 from moe import config
 from moe.library import Album, Extra, LibItem, Track
-from moe.query import query
+from moe.query import QueryType, query
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
@@ -164,7 +164,7 @@ def get_duplicates(
         :meth:`~moe.library.lib_item.LibItem.is_unique`.
     """
     if not others:
-        others = query(session, "*", type(item).__name__.lower())
+        others = query(session, "*", QueryType(type(item).__name__.lower()))
 
     return [
         other for other in others if item is not other and not item.is_unique(other)

--- a/moe/list.py
+++ b/moe/list.py
@@ -66,7 +66,7 @@ def _parse_args(session: Session, args: argparse.Namespace) -> None:
     Raises:
         SystemExit: Invalid query or no items found.
     """
-    items = cli_query(session, args.query, query_type=args.query_type)
+    items = cli_query(session, args.query, args.query_type)
     items.sort()
 
     if args.info:

--- a/moe/move/move_cli.py
+++ b/moe/move/move_cli.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.session import Session
 import moe
 from moe import move as moe_move
 from moe.library import Album
+from moe.query import QueryType
 from moe.util.cli import cli_query
 
 log = logging.getLogger("moe.cli.move")
@@ -45,7 +46,7 @@ def _parse_args(session: Session, args: argparse.Namespace) -> None:
     Raises:
         SystemExit: Invalid query or no items found to move.
     """
-    albums = cast("list[Album]", cli_query(session, "*", query_type="album"))
+    albums = cast("list[Album]", cli_query(session, "*", QueryType.ALBUM))
 
     if args.dry_run:
         dry_run_str = _dry_run(albums)

--- a/moe/remove/rm_cli.py
+++ b/moe/remove/rm_cli.py
@@ -49,7 +49,7 @@ def _parse_args(session: Session, args: argparse.Namespace) -> None:
     Raises:
         SystemExit: Invalid query given, or no items to remove.
     """
-    items = cli_query(session, args.query, query_type=args.query_type)
+    items = cli_query(session, args.query, args.query_type)
 
     for item in items:
         moe_rm.remove_item(session, item)

--- a/moe/util/cli/query.py
+++ b/moe/util/cli/query.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 from typing import TYPE_CHECKING
 
-from moe.query import QueryError, query
+from moe.query import QueryError, QueryType, query
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
@@ -50,7 +50,7 @@ query_type_group.add_argument(
     "-a",
     "--album",
     action="store_const",
-    const="album",
+    const=QueryType.ALBUM,
     dest="query_type",
     help="query for matching albums",
 )
@@ -58,22 +58,22 @@ query_type_group.add_argument(
     "-e",
     "--extra",
     action="store_const",
-    const="extra",
+    const=QueryType.EXTRA,
     dest="query_type",
     help="query for matching extras",
 )
-query_parser.set_defaults(query_type="track")
+query_parser.set_defaults(query_type=QueryType.TRACK)
 
 
 def cli_query(
-    session: Session, query_str: str, query_type: str
+    session: Session, query_str: str, query_type: QueryType
 ) -> list[Album] | list[Extra] | list[Track]:
     """Wrapper around the core query call, with some added cli error handling.
 
     Args:
         session: Library db session.
         query_str: Query string to parse. See the query docs for more info.
-        query_type: Type of library item to return: either 'album', 'extra', or 'track'.
+        query_type: Type of library item to return.
 
     Returns:
         All items matching the given query found in ``args``.

--- a/tests/edit/test_edit_cli.py
+++ b/tests/edit/test_edit_cli.py
@@ -9,6 +9,7 @@ import pytest
 import moe.cli
 from moe import config
 from moe.edit import EditError
+from moe.query import QueryType
 from tests.conftest import album_factory, extra_factory, track_factory
 
 
@@ -50,7 +51,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.TRACK)
         mock_edit.assert_called_once_with(track, "track_num", "3", create_field=False)
 
     def test_album(self, mock_query, mock_edit):
@@ -61,7 +62,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="album")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.ALBUM)
         mock_edit.assert_called_once_with(album, "title", "edit", create_field=False)
 
     def test_extra(self, mock_query, mock_edit):
@@ -72,7 +73,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="extra")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.EXTRA)
         mock_edit.assert_called_once_with(extra, "title", "edit", create_field=False)
 
     def test_multiple_items(self, mock_query, mock_edit):

--- a/tests/read/test_read_cli.py
+++ b/tests/read/test_read_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, patch
 import pytest
 
 import moe.cli
+from moe.query import QueryType
 from tests.conftest import album_factory, track_factory
 
 
@@ -48,7 +49,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.TRACK)
         mock_read.assert_called_once_with(track)
 
     def test_album(self, mock_query, mock_read):
@@ -59,7 +60,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="album")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.ALBUM)
         mock_read.assert_called_once_with(album)
 
     def test_multiple_items(self, mock_query, mock_read):
@@ -70,7 +71,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.TRACK)
         for track in tracks:
             mock_read.assert_any_call(track)
         assert mock_read.call_count == len(tracks)

--- a/tests/remove/test_rm_cli.py
+++ b/tests/remove/test_rm_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, patch
 import pytest
 
 import moe.cli
+from moe.query import QueryType
 from tests.conftest import album_factory, extra_factory, track_factory
 
 
@@ -48,7 +49,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.TRACK)
         mock_rm.assert_called_once_with(ANY, track)
 
     def test_album(self, mock_query, mock_rm):
@@ -59,7 +60,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="album")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.ALBUM)
         mock_rm.assert_called_once_with(ANY, album)
 
     def test_extra(self, mock_query, mock_rm):
@@ -70,7 +71,7 @@ class TestCommand:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="extra")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.EXTRA)
         mock_rm.assert_called_once_with(ANY, extra)
 
     def test_multiple_items(self, mock_query, mock_rm):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, patch
 import pytest
 
 import moe.cli
+from moe.query import QueryType
 from tests.conftest import album_factory, extra_factory, track_factory
 
 
@@ -41,7 +42,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.TRACK)
         assert capsys.readouterr().out.strip("\n") == str(track)
 
     def test_album(self, capsys, mock_query):
@@ -52,7 +53,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="album")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.ALBUM)
         assert capsys.readouterr().out.strip("\n") == str(album)
 
     def test_extra(self, capsys, mock_query):
@@ -63,7 +64,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="extra")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.EXTRA)
         assert capsys.readouterr().out.strip("\n") == str(extra)
 
     def test_multiple_items(self, capsys, mock_query):
@@ -85,7 +86,7 @@ class TestParseArgs:
 
         moe.cli.main(cli_args)
 
-        mock_query.assert_called_once_with(ANY, "*", query_type="track")
+        mock_query.assert_called_once_with(ANY, "*", QueryType.TRACK)
         assert capsys.readouterr().out.strip("\n") == str(track.path)
 
     def test_info_album(self, mock_query):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from moe.library import Album, Extra, Track
-from moe.query import QueryError, query
+from moe.query import QueryError, QueryType, query
 from tests.conftest import album_factory, extra_factory, track_factory
 
 
@@ -16,21 +16,21 @@ class TestQueries:
     def test_empty_query_str(self):
         """Empty queries strings should raise a QueryError."""
         with pytest.raises(QueryError):
-            query(MagicMock(), "", "track")
+            query(MagicMock(), "", QueryType.TRACK)
 
     def test_empty_query(self, tmp_session):
         """Empty queries should return an empty list."""
-        assert not query(tmp_session, "title:nope", "track")
+        assert not query(tmp_session, "title:nope", QueryType.TRACK)
 
     def test_invalid_query_str(self):
         """Invalid queries should raise a QueryError."""
         with pytest.raises(QueryError):
-            query(MagicMock(), "invalid", "track")
+            query(MagicMock(), "invalid", QueryType.TRACK)
 
     def test_invalid_querty_type_separate(self):
         """Queries can have either a : or :: separator, otherwise throw QuerError."""
         with pytest.raises(QueryError):
-            query(MagicMock(), "title$nope", "track")
+            query(MagicMock(), "title$nope", QueryType.TRACK)
 
     def test_return_type(self, tmp_session):
         """Queries return the appropriate type."""
@@ -38,9 +38,9 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        albums = query(tmp_session, f"a:title:'{album.title}'", "album")
-        extras = query(tmp_session, f"a:title:'{album.title}'", "extra")
-        tracks = query(tmp_session, f"a:title:'{album.title}'", "track")
+        albums = query(tmp_session, f"a:title:'{album.title}'", QueryType.ALBUM)
+        extras = query(tmp_session, f"a:title:'{album.title}'", QueryType.EXTRA)
+        tracks = query(tmp_session, f"a:title:'{album.title}'", QueryType.TRACK)
 
         assert albums
         for album in albums:
@@ -58,8 +58,10 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query(tmp_session, f"a:year:{album.year}", "album")
-        assert query(tmp_session, f"a:original_year:{album.original_year}", "album")
+        assert query(tmp_session, f"a:year:{album.year}", QueryType.ALBUM)
+        assert query(
+            tmp_session, f"a:original_year:{album.original_year}", QueryType.ALBUM
+        )
 
     def test_multiple_terms(self, tmp_session):
         """We should be able to query for multiple terms at once."""
@@ -67,14 +69,16 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query(tmp_session, f"a:year:{album.year} a:title:{album.title}", "album")
+        assert query(
+            tmp_session, f"a:year:{album.year} a:title:{album.title}", QueryType.ALBUM
+        )
 
     def test_regex(self, tmp_session):
         """Queries can use regular expression matching."""
         tmp_session.add(track_factory())
         tmp_session.flush()
 
-        assert query(tmp_session, "title::.*", "track")
+        assert query(tmp_session, "title::.*", QueryType.TRACK)
 
     def test_path_query(self, tmp_config, tmp_session):
         """We can query for paths."""
@@ -83,22 +87,22 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query(tmp_session, f"'a:path:{album.path.resolve()}'", "album")
-        assert query(tmp_session, "'a:path::.*'", "album")
+        assert query(tmp_session, f"'a:path:{album.path.resolve()}'", QueryType.ALBUM)
+        assert query(tmp_session, "'a:path::.*'", QueryType.ALBUM)
 
     def test_case_insensitive_value(self, tmp_session):
         """Query values should be case-insensitive."""
         tmp_session.add(album_factory(title="TMP"))
         tmp_session.flush()
 
-        assert query(tmp_session, "a:title:tmp", "album")
+        assert query(tmp_session, "a:title:tmp", QueryType.ALBUM)
 
     def test_regex_non_str(self, tmp_session):
         """Non string fields should be converted to strings for matching."""
         tmp_session.add(album_factory())
         tmp_session.flush()
 
-        assert query(tmp_session, "a:year::.*", "album")
+        assert query(tmp_session, "a:year::.*", QueryType.ALBUM)
 
     def test_invalid_regex(self, tmp_session):
         """Invalid regex queries should raise a QueryError."""
@@ -106,22 +110,22 @@ class TestQueries:
         tmp_session.flush()
 
         with pytest.raises(QueryError):
-            query(tmp_session, "title::[", "album")
+            query(tmp_session, "title::[", QueryType.ALBUM)
 
     def test_regex_case_insensitive(self, tmp_session):
         """Regex queries should be case-insensitive."""
         tmp_session.add(album_factory(title="TMP"))
         tmp_session.flush()
 
-        assert query(tmp_session, "a:title::tmp", "album")
+        assert query(tmp_session, "a:title::tmp", QueryType.ALBUM)
 
     def test_like_query(self, tmp_session):
         """Test sql LIKE queries. '%' and '_' are wildcard characters."""
         tmp_session.add(track_factory(track_num=1))
         tmp_session.flush()
 
-        assert query(tmp_session, "track_num:_", "track")
-        assert query(tmp_session, "track_num:%", "track")
+        assert query(tmp_session, "track_num:_", QueryType.TRACK)
+        assert query(tmp_session, "track_num:%", QueryType.TRACK)
 
     def test_like_escape_query(self, tmp_session):
         r"""We should be able to escape the LIKE wildcard characters with '/'.
@@ -133,29 +137,29 @@ class TestQueries:
         tmp_session.add(album_factory(title="_"))
         tmp_session.flush()
 
-        assert len(query(tmp_session, "a:title:/_", "album")) == 1
+        assert len(query(tmp_session, "a:title:/_", QueryType.ALBUM)) == 1
 
     def test_track_genre_query(self, tmp_session):
         """Querying 'genre' should use the 'genres' field."""
         tmp_session.add(track_factory(genres={"hip hop", "rock"}))
         tmp_session.flush()
 
-        assert query(tmp_session, "'genre::.*'", "track")
-        assert query(tmp_session, "'genre:hip hop'", "track")
+        assert query(tmp_session, "'genre::.*'", QueryType.TRACK)
+        assert query(tmp_session, "'genre:hip hop'", QueryType.TRACK)
 
     def test_album_catalog_num_query(self, tmp_session):
         """Querying 'catalog_num' should use the 'catalog_nums' field."""
         tmp_session.add(album_factory(catalog_nums={"1", "2"}))
         tmp_session.flush()
 
-        assert query(tmp_session, "a:catalog_num:1 a:catalog_num:2", "album")
+        assert query(tmp_session, "a:catalog_num:1 a:catalog_num:2", QueryType.ALBUM)
 
     def test_wildcard_query(self, tmp_session):
         """'*' as a query should return all items."""
         tmp_session.add(album_factory())
         tmp_session.flush()
 
-        assert len(query(tmp_session, "*", "album")) == 1
+        assert len(query(tmp_session, "*", QueryType.ALBUM)) == 1
 
     def test_missing_extras_tracks(self, tmp_session):
         """Ensure albums without extras or tracks."""
@@ -164,7 +168,7 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert len(query(tmp_session, "*", "album")) == 1
+        assert len(query(tmp_session, "*", QueryType.ALBUM)) == 1
 
     def test_custom_fields(self, tmp_session):
         """We can query a custom field."""
@@ -175,7 +179,9 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query(tmp_session, "a:blah:album t:blah:track e:blah:extra", "album")
+        assert query(
+            tmp_session, "a:blah:album t:blah:track e:blah:extra", QueryType.ALBUM
+        )
 
     def test_custom_field_regex(self, tmp_session):
         """We can regex query a custom field."""
@@ -186,7 +192,9 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query(tmp_session, "a:blah::albu. t:blah::trac. e:blah::3", "album")
+        assert query(
+            tmp_session, "a:blah::albu. t:blah::trac. e:blah::3", QueryType.ALBUM
+        )
 
     def test_custom_list_field(self, tmp_session):
         """We can query custom list fields."""
@@ -197,30 +205,32 @@ class TestQueries:
         tmp_session.add(album)
         tmp_session.flush()
 
-        assert query(tmp_session, "a:blah:album t:blah:track e:blah:extra", "album")
-        assert query(tmp_session, "a:blah:1 e:blah:2 t:blah:3", "album")
-        assert query(tmp_session, "t:blah:3 t:blah:track", "album")
+        assert query(
+            tmp_session, "a:blah:album t:blah:track e:blah:extra", QueryType.ALBUM
+        )
+        assert query(tmp_session, "a:blah:1 e:blah:2 t:blah:3", QueryType.ALBUM)
+        assert query(tmp_session, "t:blah:3 t:blah:track", QueryType.ALBUM)
 
     def test_numeric_query_range(self, tmp_session):
         """We can query for a range."""
         tmp_session.add(track_factory(track_num=2))
         tmp_session.flush()
 
-        assert query(tmp_session, "t:track_num:1..3", "track")
+        assert query(tmp_session, "t:track_num:1..3", QueryType.TRACK)
 
     def test_numeric_lt(self, tmp_session):
         """Numeric queries without a lower bound test less than the upper bound."""
         tmp_session.add(track_factory(track_num=1))
         tmp_session.flush()
 
-        assert query(tmp_session, "t:track_num:..3", "track")
+        assert query(tmp_session, "t:track_num:..3", QueryType.TRACK)
 
     def test_numeric_gt(self, tmp_session):
         """Numeric queries without an upper bound test greater than the lower bound."""
         tmp_session.add(track_factory(track_num=2))
         tmp_session.flush()
 
-        assert query(tmp_session, "t:track_num:1..", "track")
+        assert query(tmp_session, "t:track_num:1..", QueryType.TRACK)
 
     def test_numeric_query_inclusive(self, tmp_session):
         """Numeric queries should be inclusive of their upper or lower bounds."""
@@ -228,6 +238,12 @@ class TestQueries:
         tmp_session.add_all(tracks)
         tmp_session.flush()
 
-        assert len(query(tmp_session, "t:track_num:1..3", "track")) == len(tracks)
-        assert len(query(tmp_session, "t:track_num:1..", "track")) == len(tracks)
-        assert len(query(tmp_session, "t:track_num:..3", "track")) == len(tracks)
+        assert len(query(tmp_session, "t:track_num:1..3", QueryType.TRACK)) == len(
+            tracks
+        )
+        assert len(query(tmp_session, "t:track_num:1..", QueryType.TRACK)) == len(
+            tracks
+        )
+        assert len(query(tmp_session, "t:track_num:..3", QueryType.TRACK)) == len(
+            tracks
+        )

--- a/tests/util/cli/test_query.py
+++ b/tests/util/cli/test_query.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from moe.query import QueryError
-from moe.util.cli import cli_query
+from moe.query import QueryError, QueryType
+from moe.util.cli import cli_query, query_parser
 
 
 @pytest.fixture
@@ -32,10 +32,10 @@ class TestCLIQuery:
         mock_session = MagicMock()
 
         with pytest.raises(SystemExit) as error:
-            cli_query(mock_session, "bad query", "track")
+            cli_query(mock_session, "bad query", QueryType.TRACK)
 
         assert error.value.code != 0
-        mock_query.assert_called_once_with(mock_session, "bad query", "track")
+        mock_query.assert_called_once_with(mock_session, "bad query", QueryType.TRACK)
 
     def test_empty_query(self, mock_query):
         """Exit with non-zero code if bad query given."""
@@ -43,7 +43,58 @@ class TestCLIQuery:
         mock_session = MagicMock()
 
         with pytest.raises(SystemExit) as error:
-            cli_query(mock_session, "*", "track")
+            cli_query(mock_session, "*", QueryType.TRACK)
 
         assert error.value.code != 0
-        mock_query.assert_called_once_with(mock_session, "*", "track")
+        mock_query.assert_called_once_with(mock_session, "*", QueryType.TRACK)
+
+    def test_good_query(self, mock_query):
+        """Call a good query if items passed."""
+        mock_query.return_value = ["item1", "item2"]
+        mock_session = MagicMock()
+
+        items = cli_query(mock_session, "*", QueryType.TRACK)
+
+        assert items == ["item1", "item2"]
+        mock_query.assert_called_once_with(mock_session, "*", QueryType.TRACK)
+
+
+class TestQueryParser:
+    """Test `query_parser`."""
+
+    def test_query_arg(self):
+        """A query is correctly parsed."""
+        args = query_parser.parse_args(["my query"])
+
+        assert args.query == "my query"
+
+    def test_default_query_type(self):
+        """The query_type defaults to 'track'."""
+        args = query_parser.parse_args(["my query"])
+
+        assert args.query_type == QueryType.TRACK
+
+    @pytest.mark.parametrize("album_flag", ["-a", "--album"])
+    def test_album_query_type(self, album_flag):
+        """The query_type is 'album' if an album flag is specified."""
+        args = query_parser.parse_args([album_flag, "my query"])
+
+        assert args.query_type == QueryType.ALBUM
+
+    @pytest.mark.parametrize("extra_flag", ["-e", "--extra"])
+    def test_extra_query_type(self, extra_flag):
+        """The query_type is 'extra' if an extra flag is specified."""
+        args = query_parser.parse_args([extra_flag, "my query"])
+
+        assert args.query_type == QueryType.EXTRA
+
+    @pytest.mark.parametrize("flags", [("-a", "-e"), ("--album", "--extra")])
+    def test_mutually_exclusive(self, flags):
+        """We can't have more than one query_type."""
+        with pytest.raises(SystemExit):
+            query_parser.parse_args([*flags, "my query"])
+
+    def test_no_query(self):
+        """A query must be specified."""
+        with pytest.raises(SystemExit):
+            query_parser.parse_args([])


### PR DESCRIPTION
### Description
The `query_type` parameter for `moe.query.query()` and `moe.util.cli.cli_query()` is changed from a raw string to a `QueryType` enum.

This change improves the overall robustness and developer experience of the query API by providing:
- Type safety to prevent passing invalid string values.
- Compile-time error checking for typos (e.g., "albuum").
- Better autocompletion and self-documentation within IDEs.

BREAKING CHANGE: The function signature of `moe.query.query()` and its CLI wrapper `moe.util.cli.cli_query()` has changed. Any external plugins or scripts that directly call these functions will need to be updated to import and use the =QueryType= enum.

Before:
`query(session, "*", "track")`

After:
```
from moe.query import QueryType
query(session, "*", QueryType.TRACK)
```

<!-- Description of the changes this pull request makes. -->


<!-- Add any additional information necessary to explain your changes. You can use this section to also link to other issues or discussions. -->
### Additional information

<!-- If the pull request is still a WIP, please mark the pull request as a draft. If you'd like to request a review while it's a draft, you can do so under the `Reviewers` pane in the top right of the pull request.-->


<!-- readthedocs-preview mrmoe start -->
----
📚 Documentation preview 📚: https://mrmoe--339.org.readthedocs.build/en/339/

<!-- readthedocs-preview mrmoe end -->